### PR TITLE
run --diff command without config file

### DIFF
--- a/lib/jnpr/jsnapy/jsnapy.py
+++ b/lib/jnpr/jsnapy/jsnapy.py
@@ -869,8 +869,7 @@ class SnapAdmin:
         """
         if((self.args.snap is True and (self.args.pre_snapfile is None or self.args.file is None)) or
             (self.args.snapcheck is True and self.args.file is None) or
-            (self.args.check is True and self.args.file is None) or
-            (self.args.diff is True and self.args.file is None)
+            (self.args.check is True and self.args.file is None)
            ):
             self.logger.error(
                 "Arguments not given correctly, Please refer help message", extra=self.log_detail)


### PR DESCRIPTION
If full path of both snap file is given, then JSNAPy will test two snap files without using config file.
If complete path of both snap file is not given, then config file is required.
