### PR TITLE
modifying snapfilename, replace all special characters with underscore

### DIFF
--- a/lib/jnpr/jsnapy/check.py
+++ b/lib/jnpr/jsnapy/check.py
@@ -8,6 +8,7 @@ from jnpr.jsnapy.xml_comparator import XmlComparator
 import colorama
 import logging
 from jnpr.jsnapy import get_path
+import re
 
 
 class Comparator:
@@ -20,13 +21,14 @@ class Comparator:
     def __del__(self):
         colorama.init(autoreset=True)
 
-    def generate_snap_file(self, device, prefix, cmd_rpc_name, reply_format):
+    def generate_snap_file(self, device, prefix, name, reply_format):
         """
         This function generates name of snapshot files
         """
         if os.path.isfile(prefix):
             return prefix
         else:
+            cmd_rpc_name = re.sub('/|\*|\.|-','_', name)
             sfile = str(device) + '_' + prefix + '_' + \
                 cmd_rpc_name + '.' + reply_format
             snapfile = os.path.join(

--- a/lib/jnpr/jsnapy/snap.py
+++ b/lib/jnpr/jsnapy/snap.py
@@ -5,6 +5,7 @@ import sys
 import logging
 import colorama
 from jnpr.jsnapy import get_path
+import re
 
 
 class Parser:
@@ -80,11 +81,12 @@ class Parser:
         :param cmd_format: xml/text
         :return: return output file
         """
+        cmd_rpc = re.sub('/|\*|\.|-','_', name)
         if os.path.isfile(output_file):
             return output_file
         else:
             filename = hostname + '_' + output_file + \
-                '_' + name + '.' + cmd_format
+                '_' + cmd_rpc + '.' + cmd_format
             output_file = os.path.join(
                 get_path(
                     'DEFAULT',


### PR DESCRIPTION
Resolving PR #1165371
Replace all special characters with '_' while creating snap file name 

For example:

```
       1. for command show interface terse ge-0/0/0   
                     name is:  router_pre_show_interfaces_terse_ge_0_0_0.xml
       2. for command show interface terse lo* 
                    name is:   router_post_show_interfaces_terse_lo_.xml        
```
