### PR TITLE
renaming args to kwargs in RPC

### DIFF
--- a/lib/jnpr/jsnapy/samples/test_filter.yml
+++ b/lib/jnpr/jsnapy/samples/test_filter.yml
@@ -3,5 +3,5 @@ tests_include:
 
 test_rpc_version:
   - rpc: get-config
-  - args:
+  - kwargs:
       filter_xml: configuration/system/login

--- a/lib/jnpr/jsnapy/samples/test_get_config.yml
+++ b/lib/jnpr/jsnapy/samples/test_get_config.yml
@@ -4,7 +4,7 @@ tests_include:
 
 test_rpc_version:
   - rpc: get-config
-  - args:
+  - kwargs:
       filter_xml: configuration/system/login
   - item:
       xpath: //configuration
@@ -16,7 +16,7 @@ test_rpc_version:
 test_interface:
   - rpc: get-interface-information
     #format: text
-  - args:
+  - kwargs:
       interface-name: em0
       media: True
       detail: True

--- a/tests/unit/configs/test_rpc.yml
+++ b/tests/unit/configs/test_rpc.yml
@@ -4,7 +4,7 @@ tests_include:
 
 test_rpc_version:
   - rpc: get-config
-  - args:
+  - kwargs:
       filter_xml: configuration/system/login
   - item:
       xpath: //configuration
@@ -16,7 +16,7 @@ test_rpc_version:
 test_interface:
   - rpc: get-interface-information
     format: xml
-  - args:
+  - kwargs:
       interface-name: em0
       media: True
       detail: True

--- a/tests/unit/configs/test_rpc_error.yml
+++ b/tests/unit/configs/test_rpc_error.yml
@@ -4,7 +4,7 @@ tests_include:
 test_interface:
   - rpc: get-interface-information
     format: xml
-  - args:
+  - kwargs:
       filter_xml: configuration/system/login
       interface-name: em0
       media: True

--- a/tests/unit/configs/test_rpc_error_2.yml
+++ b/tests/unit/configs/test_rpc_error_2.yml
@@ -4,7 +4,7 @@ tests_include:
 test_interface:
   - rpc: get-interface-infomation
     format: xml
-  - args:
+  - kwargs:
       interface-name: em0
       media: True
       detail: True

--- a/tests/unit/configs/test_rpc_error_3.yml
+++ b/tests/unit/configs/test_rpc_error_3.yml
@@ -4,7 +4,7 @@ tests_include:
 test_interface:
   - rpc: get-interface-information
     format: text
-  - args:
+  - kwargs:
       interface-name: emrt323210
       media: True
       detail: True


### PR DESCRIPTION
In case of RPC, use kwargs in place of args, for giving arguments to filter configuration.
