### PR TITLE
modified info level messages in case of test pass and fail

### DIFF
--- a/lib/jnpr/jsnapy/testop.py
+++ b/lib/jnpr/jsnapy/testop.py
@@ -771,10 +771,10 @@ class Operator:
                         res = False
                         count_fail = count_fail + 1
         if res is False:
-            msg = 'All "%s" is greater than  "%d" [ %d matched / %d failed ]'%(element, val1, count_pass, count_fail)
+            msg = 'All "%s" is not greater than  "%d" [ %d matched / %d failed ]'%(element, val1, count_pass, count_fail)
             self._print_result(msg, res)
         else:
-            msg = 'All "%s" is not greater than %d" [ %d matched ]'%(element, val1, count_pass)
+            msg = 'All "%s" is greater than %d" [ %d matched ]'%(element, val1, count_pass)
             self._print_result(msg, res)
 
         tresult['result'] = res
@@ -846,10 +846,10 @@ class Operator:
                         res = False
                         count_fail = count_fail + 1
         if res is False:
-            msg = 'All "%s" is less than %d" [ %d matched / %d failed ]'%(element, val1, count_pass, count_fail)
+            msg = 'All "%s" is not less than %d" [ %d matched / %d failed ]'%(element, val1, count_pass, count_fail)
             self._print_result(msg, res)
         else:
-            msg = 'All "%s" is not less than %d [ %d matched ]'%(element, val1, count_pass)
+            msg = 'All "%s" is less than %d [ %d matched ]'%(element, val1, count_pass)
             self._print_result(msg, res)
 
         tresult['result'] = res
@@ -923,10 +923,10 @@ class Operator:
                         res = False
                         count_fail = count_fail + 1
         if res is False:
-            msg = 'All "%s" contains %s" [ %d matched / %d failed ]'%(element, value, count_pass, count_fail)
+            msg = 'All "%s" do not contains %s" [ %d matched / %d failed ]'%(element, value, count_pass, count_fail)
             self._print_result(msg, res)
         else:
-            msg = 'All "%s" do not contains %s [ %d matched ]'%(element, value, count_pass)
+            msg = 'All "%s" contains %s [ %d matched ]'%(element, value, count_pass)
             self._print_result(msg, res)
 
         tresult['result'] = res


### PR DESCRIPTION
Default logging level is DEBUG.
In case of info logging level, JSNAPy will now print messages like:

``` python
PASS | All "admin-status" is post snapshot is present in pre snapshot [ 1 matched ]
FAIL | All "memory-heap-utilization" is not in delta difference from 50% [ 0 matched / 1 failed ]
```
