### PR TITLE
Printing help message in case of incorrect arguments 

### DIFF
--- a/lib/jnpr/jsnapy/jsnapy.py
+++ b/lib/jnpr/jsnapy/jsnapy.py
@@ -877,6 +877,13 @@ class SnapAdmin:
         set of combination is not given.
         :return: print message in command line, regarding correct usage of JSNAPy
         """
+        ## only four test operation is permitted, if given anything apart from this, then it should print error message
+        if (self.args.snap is False and self.args.snapcheck is False and self.args.check is False and self.args.diff is False):
+            self.logger.error(colorama.Fore.RED +
+                              "Arguments not given correctly, Please refer help message", extra=self.log_detail)
+            self.parser.print_help()
+            sys.exit(1)
+
         if((self.args.snap is True and (self.args.pre_snapfile is None or self.args.file is None)) or
             (self.args.snapcheck is True and self.args.file is None) or
             (self.args.check is True and self.args.file is None)


### PR DESCRIPTION
If arguments are not given properly, then it should print help message.

```
(venv)sh-3.2# jsnapy snappy -f mam_single_gt.yml 
Arguments not given correctly, Please refer help message
usage: 
 This tool enables you to capture and audit runtime environment snapshots of your networked devices running the Junos operating system (Junos OS)

Tool to capture snapshots and compare them
It supports four subcommands:
 --snap, --check, --snapcheck, --diff
1. Take snapshot:
        jsnapy --snap pre_snapfile -f main_configfile
2. Compare snapshots:
        jsnapy --check post_snapfile pre_snapfile -f main_configfile
3. Compare current configuration:
        jsnapy --snapcheck snapfile -f main_configfile
4. Take diff without specifying test case:
        jsnapy --diff pre_snapfile post_snapfile -f main_configfile

positional arguments:
  pre_snapfile          pre snapshot filename
  post_snapfile         post snapshot filename

optional arguments:
  -h, --help            show this help message and exit
  --snap                take the snapshot for commands specified in test file
  --check               compare pre and post snapshots based on test operators
                        specified in test file
  --snapcheck           check current snapshot based on test file
  --diff                display difference between two snapshots
  --version             displays version
  -f FILE, --file FILE  config file to take snapshot
  -t HOSTNAME, --hostname HOSTNAME
                        hostname
  -p PASSWD, --passwd PASSWD
                        password to login
  -l LOGIN, --login LOGIN
                        username to login
(venv)sh-3.2#
```
