### PR TITLE
adding functionality to pass port no

### DIFF
--- a/lib/jnpr/jsnapy/testop.py
+++ b/lib/jnpr/jsnapy/testop.py
@@ -1239,6 +1239,7 @@ class Operator:
                                 count_pass = count_pass + 1
                                 self._print_message(info_mssg, iddict, predict, postdict, "debug")
                     else:
+                        count_pass = count_pass + 1
                         self._print_message(info_mssg, iddict, predict, postdict)
 
                 else:
@@ -1316,6 +1317,7 @@ class Operator:
                                 count_pass = count_pass + 1
                                 self._print_message(info_mssg, iddict, predict, postdict, "debug")
                     else:
+                        count_pass = count_pass + 1
                         self._print_message(info_mssg, iddict, predict, postdict, "debug")
                 else:
                     tresult['id_miss_match'] = []
@@ -1333,7 +1335,7 @@ class Operator:
             msg = 'All "{0}" in post snapshot is not present in pre snapshot [ {1} matched / {2} failed ]'.format(tresult['node_name'], count_pass, count_fail)
             self._print_result(msg, res)
         else:
-            msg = 'All "{0}" is post snapshot is present in pre snapshot [ {1} matched ]'.format(tresult['node_name'], count_pass)
+            msg = 'All "{0}" in post snapshot is present in pre snapshot [ {1} matched ]'.format(tresult['node_name'], count_pass)
             self._print_result(msg, res)
 
         tresult['result'] = res


### PR DESCRIPTION
Now you can pass port no also:

```
hosts:
  - device: 100.219.16.204
    username : foo
    passwd: baar
    port: 830
tests:
#  - test_is_gt.yml
```

output:

```
(venv)sh-3.2# jsnapy --snapcheck -f /etc/jsnapy/testfiles/config_single_snapcheck_port.yml 
Connecting to device 100.219.16.204................
Taking snapshot for show interfaces terse ................
*************************** Device: 100.219.16.204***************************
Tests Included: test_interfaces_terse 
*********************** Command: show interfaces terse ***********************
Test Failed !! admin-status of interface <cbp0> is not equal to down, it is <up> with oper-status <up>
Test Failed !! admin-status of interface <demux0> is not equal to down, it is <up> with oper-status <up>
Test Failed !! admin-status of interface <dsc> is not equal to down, it is <up> with oper-status <up>
Test Failed !! admin-status of interface <em0> is not equal to down, it is <up> with oper-status <up>
Test Failed !! admin-status of interface <esi> is not equal to down, it is <up> with oper-status <up>
Test Failed !! admin-status of interface <gre> is not equal to down, it is <up> with oper-status <up>
Test Failed !! admin-status of interface <ipip> is not equal to down, it is <up> with oper-status <up>
Test Failed !! admin-status of interface <irb> is not equal to down, it is <up> with oper-status <up>
Test Failed !! admin-status of interface <lo0> is not equal to down, it is <up> with oper-status <up>
Test Failed !! admin-status of interface <lsi> is not equal to down, it is <up> with oper-status <up>
Test Failed !! admin-status of interface <mtun> is not equal to down, it is <up> with oper-status <up>
Test Failed !! admin-status of interface <pimd> is not equal to down, it is <up> with oper-status <up>
Test Failed !! admin-status of interface <pime> is not equal to down, it is <up> with oper-status <up>
Test Failed !! admin-status of interface <pip0> is not equal to down, it is <up> with oper-status <up>
Test Failed !! admin-status of interface <pp0> is not equal to down, it is <up> with oper-status <up>
Test Failed !! admin-status of interface <tap> is not equal to down, it is <up> with oper-status <up>
Test Failed !! admin-status of interface <vtep> is not equal to down, it is <up> with oper-status <up>
FAIL | All "admin-status" is not equal to "down" [ 0 matched / 17 failed ]
------------------------------- Final Result!! -------------------------------
Total No of tests passed: 0
Total No of tests failed: 1 
Overall Tests failed!!! 
```

For negative test:

```
hosts:
  - device: 10.209.16.204
    username : foo
    passwd: bar
    port: 8030
tests:
...
```

output:

```
(venv)sh-3.2# jsnapy --snapcheck -f /etc/jsnapy/testfiles/config_single_snapcheck_port.yml 
Connecting to device 10.209.16.204 ................

ERROR occurred ConnectRefusedError(10.209.16.204)
Traceback (most recent call last):
  File "/Users/jpriyal/Desktop/developement/systest/venv/bin/jsnapy", line 9, in <module>
    load_entry_point('jsnapy==0.1', 'console_scripts', 'jsnapy')()
  File "/Users/jpriyal/Desktop/developement/systest/venv/lib/python2.7/site-packages/jnpr/jsnapy/jsnapy.py", line 948, in main
    js.get_hosts()
  File "/Users/jpriyal/Desktop/developement/systest/venv/lib/python2.7/site-packages/jnpr/jsnapy/jsnapy.py", line 309, in get_hosts
    self.login(output_file)
  File "/Users/jpriyal/Desktop/developement/systest/venv/lib/python2.7/site-packages/jnpr/jsnapy/jsnapy.py", line 491, in login
    self.connect(hostname, username, password, output_file, **key_value)
  File "/Users/jpriyal/Desktop/developement/systest/venv/lib/python2.7/site-packages/jnpr/jsnapy/jsnapy.py", line 606, in connect
    raise Exception(ex)
Exception: ConnectRefusedError(10.209.16.204)
```
