### PR TITLE
Adding new test operator: regex

### DIFF
--- a/lib/jnpr/jsnapy/testop.py
+++ b/lib/jnpr/jsnapy/testop.py
@@ -69,10 +69,10 @@ class Operator:
             self.logger_testop.error(colorama.Fore.RED +
                                      "ERROR!! Complete message: %s" % e.message, extra=self.log_detail)
             self.no_failed = self.no_failed + 1
-       # except Exception as ex:
-       #     self.logger_testop.error(colorama.Fore.RED +
-       #                              "ERROR!! Complete message: %s" % str(ex), extra=self.log_detail)
-       #     self.no_failed = self.no_failed + 1
+        except Exception as ex:
+            self.logger_testop.error(colorama.Fore.RED +
+                                     "ERROR!! Complete message: %s" % str(ex), extra=self.log_detail)
+            self.no_failed = self.no_failed + 1
 
 
     def _print_result(self, testmssg, result):


### PR DESCRIPTION
It can be used to compare node values using regular expression:

```
(venv)sh-3.2# cat test_regx.yml 
test_interfaces_terse:
  - command: show interfaces terse  
  - iterate:
      xpath: //physical-interface/name[starts-with(normalize-space(text()),'ge-')] 
      tests:
        - regex: ../name , ge-\d/\d/\d 
          info: "Test Succeeded !! name is equal to <{{post['../name']}}> "
          err: "Test Failed !! name is equal to <{{post['../name']}}> "
```

Output:

```
(venv)sh-3.2# jsnapy --snapcheck -f config_single_snapcheck.yml 
Connecting to device adora ................
Taking snapshot for show interfaces terse ................
******************************* Device: adora *******************************
Tests Included: test_interfaces_terse 
*********************** Command: show interfaces terse ***********************
PASS | All "../name" matches with regex "ge-\d/\d/\d" [ 20 matched ]
------------------------------- Final Result!! -------------------------------
Total No of tests passed: 1
Total No of tests failed: 0 
Overall Tests passed!!! 
```
