### PR TITLE
adding traceback for detailed erorr message

### DIFF
--- a/lib/jnpr/jsnapy/jsnapy.py
+++ b/lib/jnpr/jsnapy/jsnapy.py
@@ -969,7 +969,14 @@ def main():
         else:
             if js.args.verbosity:
                 js.set_verbosity(10*js.args.verbosity)
-            js.get_hosts()
+            try:
+                js.get_hosts()
+            except yaml.scanner.ScannerError as ex:
+                js.logger.error(colorama.Fore.RED +
+                                "ERROR!! YAML file not defined properly, \nComplete Message: %s" % str(ex), extra=js.log_detail)
+            except Exception as ex:
+                js.logger.error(colorama.Fore.RED +
+                                "ERROR!! %s \nComplete Message:  %s" % (type(ex).__name__, str(ex)), extra=js.log_detail)
 
 if __name__ == '__main__':
     main()

--- a/lib/jnpr/jsnapy/testop.py
+++ b/lib/jnpr/jsnapy/testop.py
@@ -70,12 +70,14 @@ class Operator:
                 *args)
         except AttributeError as e:
             self.logger_testop.error(colorama.Fore.RED +
-                                     "ERROR!! Complete message: %s" % e.message, extra=self.log_detail)
+                                     "ERROR!! AttributeError \nComplete Message: %s" % e.message, extra=self.log_detail)
+            self.no_failed = self.no_failed + 1
+        except etree.XPathEvalError as ex:
+            self.logger_testop.error(colorama.Fore.RED + "Error in evaluating XPATH, \nComplete Message: %s" % ex.message, extra=self.log_detail )
             self.no_failed = self.no_failed + 1
         except Exception as ex:
             self.logger_testop.error(colorama.Fore.RED +
-                                     "ERROR!! %s" % str(ex), extra=self.log_detail)
-            self.logger_testop.error(colorama.Fore.RED + "Complete Error message:\n {}".format(traceback.format_exc()), extra=self.log_detail)
+                                     "ERROR!! %s \nComplete Message: %s" % (type(ex).__name__, str(ex)), extra=self.log_detail)
             self.no_failed = self.no_failed + 1
 
     def _print_result(self, testmssg, result):


### PR DESCRIPTION
Output will be displayed like this:

```
(venv)sh-3.2# jsnapy --snapcheck -f config_single_snapcheck.yml 
Connecting to device adora ................
ERROR!! YAML file not defined properly, 
Complete Message: mapping values are not allowed here
  in "err.yml", line 8, column 15


(venv)sh-3.2# 
(venv)sh-3.2# jsnapy --snapcheck -f config_single_snapcheck.yml 
Connecting to device adora ................
Taking snapshot for show chassis routing-engine ................
******************************* Device: adora *******************************
Tests Included: test_re 
******************** Command: show chassis routing-engine ********************
-----------------------Performing exists Test Operation-----------------------
Error in evaluating XPATH, 
Complete Message: Invalid predicate
------------------------------- Final Result!! -------------------------------
Total No of tests passed: 0
Total No of tests failed: 1 
Overall Tests failed!!! 
```
