### PR TITLE
Added test based mail support

### DIFF
--- a/lib/jnpr/jsnapy/jsnapy.py
+++ b/lib/jnpr/jsnapy/jsnapy.py
@@ -538,9 +538,31 @@ class SnapAdmin:
                 snap_file,
                 post_snap,
                 action)
-        if config_data.get("mail") and self.args.diff is not True:
-            mfile = os.path.join(get_path('DEFAULT', 'test_file_path'), config_data.get('mail'))\
-                if os.path.isfile(config_data.get('mail')) is False else config_data.get('mail')
+
+        result_status = res.result
+        
+        mail_condition = 'all'
+        if result_status == 'Passed':
+            mail_condition = 'pass'
+        elif result_status == 'Failed':
+            mail_condition = 'fail'
+
+        mail_pref =  config_data.get("mail") 
+
+        #we don't want to send mail if only diff operation is run
+        if  mail_pref is not None and self.args.diff is False:
+            
+            if type(mail_pref) is str:
+                mail_file_path = mail_pref
+            elif type(mail_pref) is dict:
+                mail_file_path = mail_pref.get(mail_condition)
+            else:
+                self.logger.error(
+                    colorama.Fore.RED +
+                    "ERROR!! Type of mail preferences should be either dictionary or string", extra=self.log_detail)
+
+            mfile = os.path.join(get_path('DEFAULT', 'test_file_path'), mail_file_path)\
+                    if os.path.isfile(mail_file_path) is False else mail_file_path
             if os.path.isfile(mfile):
                 mail_file = open(mfile, 'r')
                 mail_file = yaml.load(mail_file)
@@ -549,7 +571,7 @@ class SnapAdmin:
                         "Please enter ur email password ")
                 else:
                     passwd = mail_file['passwd']
-               
+            
                 send_mail = Notification()
                 send_mail.notify(mail_file, hostname, passwd, res)
             else:

--- a/lib/jnpr/jsnapy/jsnapy.py
+++ b/lib/jnpr/jsnapy/jsnapy.py
@@ -531,6 +531,13 @@ class SnapAdmin:
         :return: object of testop.Operator containing test details
         """
         res = Operator()
+
+        res = self.compare_tests(
+                hostname,
+                config_data,
+                snap_file,
+                post_snap,
+                action)
         if config_data.get("mail") and self.args.diff is not True:
             mfile = os.path.join(get_path('DEFAULT', 'test_file_path'), config_data.get('mail'))\
                 if os.path.isfile(config_data.get('mail')) is False else config_data.get('mail')
@@ -542,25 +549,20 @@ class SnapAdmin:
                         "Please enter ur email password ")
                 else:
                     passwd = mail_file['passwd']
-                res = self.compare_tests(
-                    hostname,
-                    config_data,
-                    snap_file,
-                    post_snap,
-                    action)
+               
                 send_mail = Notification()
                 send_mail.notify(mail_file, hostname, passwd, res)
             else:
                 self.logger.error(
                     colorama.Fore.RED +
                     "ERROR!! Path of file containing mail content is not correct", extra=self.log_detail)
-        else:
-            res = self.compare_tests(
-                hostname,
-                config_data,
-                snap_file,
-                post_snap,
-                action)
+        # else:
+        #     res = self.compare_tests(
+        #         hostname,
+        #         config_data,
+        #         snap_file,
+        #         post_snap,
+        #         action)
 
         self.q.put(res)
         return res

--- a/tests/unit/configs/mail_fail.yml
+++ b/tests/unit/configs/mail_fail.yml
@@ -1,0 +1,5 @@
+to: reciever@gmail.com
+from: sender@gmail.com
+sub: "Sample Jsnap Results, please verify"
+recipient_name: recipient
+sender_name: "Juniper Networks"

--- a/tests/unit/configs/mail_pass.yml
+++ b/tests/unit/configs/mail_pass.yml
@@ -1,0 +1,6 @@
+to: reciever@gmail.com
+from: sender@gmail.com
+passwd: pass
+sub: "Sample Jsnap Results, please verify"
+recipient_name: recipient
+sender_name: "Juniper Networks"

--- a/tests/unit/configs/main_mail_condition.yml
+++ b/tests/unit/configs/main_mail_condition.yml
@@ -1,0 +1,19 @@
+# for one device, can be given like this:
+hosts:
+  - device: 10.216.193.114
+    username : abc
+    passwd: xyz
+tests:
+  - delta.yml
+sqlite:
+  - store_in_sqlite: no
+    check_from_sqlite: yes
+    database_name: jbb.db
+    compare: 0,1
+
+mail: 
+    pass: mail_pass.yml
+    fail: mail_fail.yml
+    all:  mail.yml
+
+

--- a/tests/unit/configs/main_mail_incomplete_condition.yml
+++ b/tests/unit/configs/main_mail_incomplete_condition.yml
@@ -1,0 +1,18 @@
+# for one device, can be given like this:
+hosts:
+  - device: 10.216.193.114
+    username : abc
+    passwd: xyz
+tests:
+  - delta.yml
+sqlite:
+  - store_in_sqlite: no
+    check_from_sqlite: yes
+    database_name: jbb.db
+    compare: 0,1
+
+mail: 
+    pass: mail_pass.yml
+    all:  mail.yml
+
+

--- a/tests/unit/configs/main_mail_wrong.yml
+++ b/tests/unit/configs/main_mail_wrong.yml
@@ -1,0 +1,18 @@
+# for one device, can be given like this:
+hosts:
+  - device: 10.216.193.114
+    username : abc
+    passwd: xyz
+tests:
+  - delta.yml
+sqlite:
+  - store_in_sqlite: no
+    check_from_sqlite: yes
+    database_name: jbb.db
+    compare: 0,1
+
+mail: 
+    - pass: mail_pass.yml
+      all:  mail.yml
+
+

--- a/tests/unit/test_jsnapy.py
+++ b/tests/unit/test_jsnapy.py
@@ -322,6 +322,121 @@ class TestSnapAdmin(unittest.TestCase):
         self.assertTrue(mock_notify.called)
 
 
+    
+    
+    
+    
+    @patch('argparse.ArgumentParser.exit')
+    @patch('jnpr.jsnapy.SnapAdmin.compare_tests')
+    @patch('getpass.getpass')
+    @patch('jnpr.jsnapy.notify.Notification.notify')
+    @patch('jnpr.jsnapy.jsnapy.get_path')
+    def test_conditional_mail_1(self, mock_path, mock_notify, mock_pass, mock_compare, mock_arg):
+        js = SnapAdmin()
+        js.args.file = os.path.join(os.path.dirname(__file__),
+                                    'configs', 'main_mail_condition.yml')
+        js.args.check = True
+        js.args.snap = False
+        js.args.snapcheck = False
+        js.args.pre_snapfile = "mock_snap"
+        js.args.post_snapfile = "mock_snap2"
+        mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
+        mock_compare.return_value = MagicMock(result = 'Failed')
+        
+        js.get_hosts()
+        self.assertTrue(mock_notify.called)
+        self.assertTrue(mock_pass.called)
+        self.assertTrue(mock_compare.called)
+
+    @patch('argparse.ArgumentParser.exit')
+    @patch('jnpr.jsnapy.SnapAdmin.compare_tests')
+    @patch('getpass.getpass')
+    @patch('jnpr.jsnapy.notify.Notification.notify')
+    @patch('jnpr.jsnapy.jsnapy.get_path')
+    def test_conditional_mail_2(self, mock_path, mock_notify, mock_pass, mock_compare, mock_arg):
+        js = SnapAdmin()
+        js.args.file = os.path.join(os.path.dirname(__file__),
+                                    'configs', 'main_mail_condition.yml')
+        js.args.diff = True
+        js.args.check = False
+        js.args.snap = False
+        js.args.snapcheck = False
+        js.args.pre_snapfile = "mock_snap"
+        js.args.post_snapfile = "mock_snap2"
+        mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
+        mock_compare.return_value = MagicMock(result = 'Failed')
+        
+        js.get_hosts()
+        self.assertFalse(mock_notify.called)
+        self.assertFalse(mock_pass.called)
+        self.assertTrue(mock_compare.called)
+
+    @patch('argparse.ArgumentParser.exit')
+    @patch('jnpr.jsnapy.SnapAdmin.compare_tests')
+    @patch('getpass.getpass')
+    @patch('jnpr.jsnapy.notify.Notification.notify')
+    @patch('jnpr.jsnapy.jsnapy.get_path')
+    def test_conditional_mail_3(self, mock_path, mock_notify, mock_pass, mock_compare, mock_arg):
+        js = SnapAdmin()
+        js.args.file = os.path.join(os.path.dirname(__file__),
+                                    'configs', 'main_mail_condition.yml')
+        js.args.check = True
+        js.args.snap = False
+        js.args.snapcheck = False
+        js.args.pre_snapfile = "mock_snap"
+        js.args.post_snapfile = "mock_snap2"
+        mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
+        mock_compare.return_value = MagicMock(result = 'Passed')
+        
+        js.get_hosts()
+        self.assertTrue(mock_notify.called)
+        self.assertFalse(mock_pass.called)
+        self.assertTrue(mock_compare.called)
+    
+    @patch('argparse.ArgumentParser.exit')
+    @patch('jnpr.jsnapy.SnapAdmin.compare_tests')
+    @patch('getpass.getpass')
+    @patch('jnpr.jsnapy.notify.Notification.notify')
+    @patch('jnpr.jsnapy.jsnapy.get_path')
+    def test_conditional_mail_4(self, mock_path, mock_notify, mock_pass, mock_compare, mock_arg):
+        js = SnapAdmin()
+        js.args.file = os.path.join(os.path.dirname(__file__),
+                                    'configs', 'main_mail_incomplete_condition.yml')
+        js.args.check = True
+        js.args.snap = False
+        js.args.snapcheck = False
+        js.args.pre_snapfile = "mock_snap"
+        js.args.post_snapfile = "mock_snap2"
+        mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
+        mock_compare.return_value = MagicMock(result = 'Failed')
+        
+        js.get_hosts()
+        self.assertFalse(mock_notify.called)
+        self.assertFalse(mock_pass.called)
+        self.assertTrue(mock_compare.called)
+
+    @patch('argparse.ArgumentParser.exit')
+    @patch('jnpr.jsnapy.SnapAdmin.compare_tests')
+    @patch('getpass.getpass')
+    @patch('jnpr.jsnapy.notify.Notification.notify')
+    @patch('jnpr.jsnapy.jsnapy.get_path')
+    def test_conditional_mail_5(self, mock_path, mock_notify, mock_pass, mock_compare, mock_arg):
+        js = SnapAdmin()
+        js.args.file = os.path.join(os.path.dirname(__file__),
+                                    'configs', 'main_mail_wrong.yml')
+        js.args.check = True
+        js.args.snap = False
+        js.args.snapcheck = False
+        js.args.pre_snapfile = "mock_snap"
+        js.args.post_snapfile = "mock_snap2"
+        mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
+        mock_compare.return_value = MagicMock(result = 'Failed')
+        
+        js.get_hosts()
+        self.assertFalse(mock_notify.called)
+        self.assertFalse(mock_pass.called)
+        self.assertTrue(mock_compare.called)
+        
     @patch('argparse.ArgumentParser.exit')
     @patch('jnpr.jsnapy.SnapAdmin.login')
     def test_sqlite_parameters_1(self, mock_login, mock_arg):

--- a/tests/unit/test_jsnapy.py
+++ b/tests/unit/test_jsnapy.py
@@ -430,13 +430,13 @@ class TestSnapAdmin(unittest.TestCase):
         js.args.pre_snapfile = "mock_snap"
         js.args.post_snapfile = "mock_snap2"
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
-        mock_compare.return_value = MagicMock(result = 'Failed')
+        mock_compare.return_value = MagicMock(result = 'Passed')
         
         js.get_hosts()
         self.assertFalse(mock_notify.called)
         self.assertFalse(mock_pass.called)
         self.assertTrue(mock_compare.called)
-        
+
     @patch('argparse.ArgumentParser.exit')
     @patch('jnpr.jsnapy.SnapAdmin.login')
     def test_sqlite_parameters_1(self, mock_login, mock_arg):


### PR DESCRIPTION
Fixed issue #133 
Compatible with older configuration files
How to use:
```
mail:
       pass: <filename>
       fail: <filename>
       all: <filename>
```
or

```mail: <filename>```
     
All the sub options are optional and in the absence of all of them nothing will happen

Also added the various unit test cases
  