### PR TITLE
Issues with /etc/jsnapy  -- #94 & #107

### DIFF
--- a/lib/jnpr/jsnapy/__init__.py
+++ b/lib/jnpr/jsnapy/__init__.py
@@ -11,7 +11,7 @@ def get_config_location(file='jsnapy.cfg'):
     p_locations = []
     if 'JSNAPY_HOME' in os.environ:
         p_locations = [os.environ['JSNAPY_HOME']]   
-    p_locations.extend(['~/.jsnapy','/etc/jsnapy'])
+    p_locations.extend([os.path.join(os.path.expanduser('~'),'.jsnapy'),'/etc/jsnapy'])
     
     for loc in p_locations:
         possible_location =  os.path.join(loc,file)

--- a/lib/jnpr/jsnapy/__init__.py
+++ b/lib/jnpr/jsnapy/__init__.py
@@ -12,9 +12,21 @@ def get_path(section, value):
     # config = ConfigParser.ConfigParser({'config_file_path': '/usr/local/share/', 'snapshot_path': '/usr/local/share/snapshots',
     #                                     'test_file_path': '/usr/local/share/testfiles', 'log_file_path': '/var/log/jsnapy'})
     config = ConfigParser.ConfigParser()
-    config_location = os.path.join('/etc', 'jsnapy', 'jsnapy.cfg')
-    if not os.path.isfile(config_location):
-        raise Exception('Config file not found at %s '%config_location)
+    config_location = None
+    
+    p_locations = []
+    if 'JSNAPY_HOME' in os.environ:
+        p_locations = [os.environ['JSNAPY_HOME']]   
+    p_locations.extend(['~/.jsnapy','/etc/jsnapy'])
+    
+    for loc in p_locations:
+        possible_location =  os.path.join(loc,'jsnapy.cfg')
+        if os.path.isfile(possible_location):
+            config_location = possible_location
+            break
+    
+    if config_location is None:
+        raise Exception('Config file not found at {0}'.format(repr(p_locations)))
     config.read(config_location)
     # config.read(os.path.join('/usr/local/share', 'jsnapy', 'jsnapy.cfg'))
     path = config.get(section, value)

--- a/lib/jnpr/jsnapy/__init__.py
+++ b/lib/jnpr/jsnapy/__init__.py
@@ -12,7 +12,10 @@ def get_path(section, value):
     # config = ConfigParser.ConfigParser({'config_file_path': '/usr/local/share/', 'snapshot_path': '/usr/local/share/snapshots',
     #                                     'test_file_path': '/usr/local/share/testfiles', 'log_file_path': '/var/log/jsnapy'})
     config = ConfigParser.ConfigParser()
-    config.read(os.path.join('/etc', 'jsnapy', 'jsnapy.cfg'))
+    config_location = os.path.join('/etc', 'jsnapy', 'jsnapy.cfg')
+    if not os.path.isfile(config_location):
+        raise Exception('Config file not found at %s '%config_location)
+    config.read(config_location)
     # config.read(os.path.join('/usr/local/share', 'jsnapy', 'jsnapy.cfg'))
     path = config.get(section, value)
     return path

--- a/lib/jnpr/jsnapy/__init__.py
+++ b/lib/jnpr/jsnapy/__init__.py
@@ -7,19 +7,17 @@ from .version import __version__
 import ConfigParser
 import os
 
-def get_config_location():
-    config_location = None
+def get_config_location(file='jsnapy.cfg'):
     p_locations = []
     if 'JSNAPY_HOME' in os.environ:
         p_locations = [os.environ['JSNAPY_HOME']]   
     p_locations.extend(['~/.jsnapy','/etc/jsnapy'])
     
     for loc in p_locations:
-        possible_location =  os.path.join(loc,'jsnapy.cfg')
+        possible_location =  os.path.join(loc,file)
         if os.path.isfile(possible_location):
-            config_location = loc
-            break
-    return config_location
+            return loc
+    return None
     
 
 def get_path(section, value):
@@ -32,7 +30,6 @@ def get_path(section, value):
         raise Exception('Config file not found')
     config_location = os.path.join(config_location,'jsnapy.cfg')
     config.read(config_location)
-    # config.read(os.path.join('/usr/local/share', 'jsnapy', 'jsnapy.cfg'))
     path = config.get(section, value)
     return path
 

--- a/lib/jnpr/jsnapy/__init__.py
+++ b/lib/jnpr/jsnapy/__init__.py
@@ -11,7 +11,8 @@ import os
 def get_path(section, value):
     config = ConfigParser.ConfigParser({'config_file_path': '/usr/local/share/', 'snapshot_path': '/usr/local/share/snapshots',
                                         'test_file_path': '/usr/local/share/testfiles', 'log_file_path': '/var/log/jsnapy'})
-    config.read(os.path.join('/usr/local/share', 'jsnapy', 'jsnapy.cfg'))
+    config.read(os.path.join('/etc', 'jsnapy', 'jsnapy.cfg'))
+    # config.read(os.path.join('/usr/local/share', 'jsnapy', 'jsnapy.cfg'))
     path = config.get(section, value)
     return path
 

--- a/lib/jnpr/jsnapy/__init__.py
+++ b/lib/jnpr/jsnapy/__init__.py
@@ -9,8 +9,9 @@ import os
 
 
 def get_path(section, value):
-    config = ConfigParser.ConfigParser({'config_file_path': '/usr/local/share/', 'snapshot_path': '/usr/local/share/snapshots',
-                                        'test_file_path': '/usr/local/share/testfiles', 'log_file_path': '/var/log/jsnapy'})
+    # config = ConfigParser.ConfigParser({'config_file_path': '/usr/local/share/', 'snapshot_path': '/usr/local/share/snapshots',
+    #                                     'test_file_path': '/usr/local/share/testfiles', 'log_file_path': '/var/log/jsnapy'})
+    config = ConfigParser.ConfigParser()
     config.read(os.path.join('/etc', 'jsnapy', 'jsnapy.cfg'))
     # config.read(os.path.join('/usr/local/share', 'jsnapy', 'jsnapy.cfg'))
     path = config.get(section, value)

--- a/lib/jnpr/jsnapy/__init__.py
+++ b/lib/jnpr/jsnapy/__init__.py
@@ -9,9 +9,9 @@ import os
 
 
 def get_path(section, value):
-    config = ConfigParser.ConfigParser({'config_file_path': '/etc/jsnapy', 'snapshot_path': '/etc/jsnapy/snapshots',
-                                        'test_file_path': '/etc/jsnapy/testfiles', 'log_file_path': '/etc/logs/jsnapy'})
-    config.read(os.path.join('/etc', 'jsnapy', 'jsnapy.cfg'))
+    config = ConfigParser.ConfigParser({'config_file_path': '/usr/local/share/', 'snapshot_path': '/usr/local/share/snapshots',
+                                        'test_file_path': '/usr/local/share/testfiles', 'log_file_path': '/var/log/jsnapy'})
+    config.read(os.path.join('/usr/local/share', 'jsnapy', 'jsnapy.cfg'))
     path = config.get(section, value)
     return path
 

--- a/lib/jnpr/jsnapy/__init__.py
+++ b/lib/jnpr/jsnapy/__init__.py
@@ -7,13 +7,8 @@ from .version import __version__
 import ConfigParser
 import os
 
-
-def get_path(section, value):
-    # config = ConfigParser.ConfigParser({'config_file_path': '/usr/local/share/', 'snapshot_path': '/usr/local/share/snapshots',
-    #                                     'test_file_path': '/usr/local/share/testfiles', 'log_file_path': '/var/log/jsnapy'})
-    config = ConfigParser.ConfigParser()
+def get_config_location():
     config_location = None
-    
     p_locations = []
     if 'JSNAPY_HOME' in os.environ:
         p_locations = [os.environ['JSNAPY_HOME']]   
@@ -22,11 +17,20 @@ def get_path(section, value):
     for loc in p_locations:
         possible_location =  os.path.join(loc,'jsnapy.cfg')
         if os.path.isfile(possible_location):
-            config_location = possible_location
+            config_location = loc
             break
+    return config_location
     
+
+def get_path(section, value):
+    # config = ConfigParser.ConfigParser({'config_file_path': '/usr/local/share/', 'snapshot_path': '/usr/local/share/snapshots',
+    #                                     'test_file_path': '/usr/local/share/testfiles', 'log_file_path': '/var/log/jsnapy'})
+    config = ConfigParser.ConfigParser()
+    
+    config_location = get_config_location()
     if config_location is None:
-        raise Exception('Config file not found at {0}'.format(repr(p_locations)))
+        raise Exception('Config file not found')
+    config_location = os.path.join(config_location,'jsnapy.cfg')
     config.read(config_location)
     # config.read(os.path.join('/usr/local/share', 'jsnapy', 'jsnapy.cfg'))
     path = config.get(section, value)

--- a/lib/jnpr/jsnapy/jsnapy.py
+++ b/lib/jnpr/jsnapy/jsnapy.py
@@ -22,7 +22,7 @@ from jnpr.jsnapy.check import Comparator
 from jnpr.jsnapy.notify import Notification
 from jnpr.junos import Device
 from jnpr.jsnapy import version
-from jnpr.jsnapy import get_path
+from jnpr.jsnapy import get_path, get_config_location
 from jnpr.jsnapy.testop import Operator
 from jnpr.junos.exception import ConnectAuthError
 
@@ -284,6 +284,10 @@ class SnapAdmin:
         read device details and connect them. Also checks sqlite key to check if user wants to
         create database for snapshots
         """
+        self.logger.debug(colorama.Fore.BLUE +
+                "jsnapy.cfg file location used : %s" %
+                get_config_location(), extra=self.log_detail)
+                
         if self.args.pre_snapfile is not None:
             output_file = self.args.pre_snapfile
         elif self.args.snapcheck is True and self.args.pre_snapfile is None:

--- a/lib/jnpr/jsnapy/setup_logging.py
+++ b/lib/jnpr/jsnapy/setup_logging.py
@@ -13,7 +13,7 @@ from jnpr.jsnapy import get_config_location
 
 def setup_logging(
         default_path='logging.yml', default_level=logging.INFO, env_key='LOG_CFG'):
-    config_location = get_config_location()
+    config_location = get_config_location('logging.yml')
     path = os.path.join(config_location, default_path)
     value = os.getenv(env_key, None)
     if value:

--- a/lib/jnpr/jsnapy/setup_logging.py
+++ b/lib/jnpr/jsnapy/setup_logging.py
@@ -8,11 +8,13 @@
 import os
 import yaml
 import logging.config
+from jnpr.jsnapy import get_config_location
 
 
 def setup_logging(
         default_path='logging.yml', default_level=logging.INFO, env_key='LOG_CFG'):
-    path = os.path.join('/etc', 'jsnapy', default_path)
+    config_location = get_config_location()
+    path = os.path.join(config_location, default_path)
     value = os.getenv(env_key, None)
     if value:
         path = value

--- a/setup.py
+++ b/setup.py
@@ -9,13 +9,15 @@ import os
 from setuptools import setup, find_packages
 from setuptools.command.install import install
 
+dir_path = '/usr/local/share/jsnapy'
 class OverrideInstall(install):
-
+    
     def run(self):
+        
         mode = 0o777
         install.run(self)
-        os.chmod('/etc/jsnapy', mode)
-        for root, dirs, files in os.walk('/etc/jsnapy'):
+        os.chmod(dir_path, mode)
+        for root, dirs, files in os.walk(dir_path):
             for directory in dirs:
                 os.chmod(os.path.join(root, directory), mode)
             for fname in files:
@@ -60,12 +62,12 @@ setup(name="jsnapy",
       scripts=['tools/jsnap2py'],
       zip_safe=False,
       install_requires=install_reqs,
-      data_files=[('/etc/jsnapy', ['lib/jnpr/jsnapy/logging.yml']),
-                  ('/etc/jsnapy/samples', example_files),
-                  ('/etc/jsnapy', ['lib/jnpr/jsnapy/jsnapy.cfg']),
-                  ('/etc/jsnapy/testfiles',
+      data_files=[(dir_path, ['lib/jnpr/jsnapy/logging.yml']),
+                  (os.path.join(dir_path,'samples'), example_files),
+                  (dir_path, ['lib/jnpr/jsnapy/jsnapy.cfg']),
+                  (os.path.join(dir_path,'testfiles'),
                    ['testfiles/README']),
-                  ('/etc/jsnapy/snapshots',
+                  (os.path.join(dir_path,'snapshots'),
                    ['snapshots/README']),
                   ('/var/log/jsnapy', log_files)
                   ],

--- a/setup.py
+++ b/setup.py
@@ -64,20 +64,24 @@ class OverrideInstall(install):
                 os.chmod(os.path.join(root, fname), mode)
         config = ConfigParser.ConfigParser()
         config.set('DEFAULT','config_file_path','/etc/jsnapy')
-        config.set('DEFAULT','snapshot_path',dir_path)
-        config.set('DEFAULT','test_file_path',dir_path)
-
-        with open("/etc/jsnapy/jsnapy.cfg",'w') as cfgfile:
-            comment = ( '# This file can be overwritten\n'
-                        '# It contains default path for\n'
-                        '# config file, snapshots and testfiles\n'
-                        '# If required, overwrite the path with your path\n'
-                        '# config_file_path: path of main config file\n'
-                        '# snapshot_path : path of snapshot file\n'
-                        '# test_file_path: path of test file\n'
-                        )
-            cfgfile.write(comment)
-            config.write(cfgfile)
+        config.set('DEFAULT','snapshot_path', os.path.join(dir_path,'snapshots'))
+        config.set('DEFAULT','test_file_path',os.path.join(dir_path,'testfiles'))
+        
+        default_config_location = "/etc/jsnapy/jsnapy.cfg"
+        if os.path.isfile(default_config_location):
+            with open(default_config_location,'w') as cfgfile:
+                comment = ( '# This file can be overwritten\n'
+                            '# It contains default path for\n'
+                            '# config file, snapshots and testfiles\n'
+                            '# If required, overwrite the path with your path\n'
+                            '# config_file_path: path of main config file\n'
+                            '# snapshot_path : path of snapshot file\n'
+                            '# test_file_path: path of test file\n\n'
+                            )
+                cfgfile.write(comment)
+                config.write(cfgfile)
+        else:
+            raise Exception('jsnapy.cfg not found at /etc/jsnapy')
 
 
 req_lines = [line.strip() for line in open(

--- a/setup.py
+++ b/setup.py
@@ -10,45 +10,19 @@ from setuptools import setup, find_packages
 from setuptools.command.install import install
 import ConfigParser
 
-# dir_path = '/etc/jsnapy'
-# dir_path = '/usr/local/share/jsnapy'
 class OverrideInstall(install):
-    # global dir_path
-    # dire = None
-    # user_options = install.user_options + [
-    #         ('dire=', 'd', 'Location for snapshots and testfiles directories'),
-    #     ] 
-    # def initialize_options(self):
-    #     install.initialize_options(self)
-    #     self.dire = None
-    #     # self.old_and_unmanageable = False
-    #     # self.single_version_externally_managed = False
-    # def finalize_options(self):
-    #     install.finalize_options(self)
-    #     dir_path = self.dire
-    #     print dir_path
+   
     def run(self):
         
-        # print sys.argv
-        # print self.install_data
         for arg in sys.argv:
             if '--install-data' in arg:
                 break
         else:
-            raise Exception("Must pass snapshot and testfile location in --install-data to setup.py")
-
-            # raise Exception
-            # dir_path = ''
-            # while dir_path =='':
-            #     dir_path= raw_input('Enter absolute directory path for testfiles and snapshots: ').strip()
-
-            # self.install_data = dir_path 
-            # # logging.error('Use --install-data to specify absolute directory path for snapshots and testfiles')
-            # exit()
+            self.install_data = '/etc/jsnapy'
+            
         dir_path = self.install_data
         mode = 0o777
         install.run(self)
-        # self.extra_dirs
         os.chmod(dir_path, mode)
         for root, dirs, files in os.walk(dir_path):
             for directory in dirs:

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@
 #
 
 import os,sys
+from os.path import expanduser
 from setuptools import setup, find_packages
 from setuptools.command.install import install
 import ConfigParser
@@ -36,7 +37,13 @@ class OverrideInstall(install):
                 os.chmod(os.path.join(root, directory), mode)
             for fname in files:
                 os.chmod(os.path.join(root, fname), mode)
-    
+        HOME = expanduser("~") #correct cross platform way to do it
+        home_folder = os.path.join(HOME,'.jsnapy')
+        if not os.path.isdir(home_folder):
+            os.mkdir(home_folder)
+            os.chmod(home_folder,mode)
+
+
         if dir_path != '/etc/jsnapy':
             config = ConfigParser.ConfigParser()
             config.set('DEFAULT','config_file_path',dir_path)

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ class OverrideInstall(install):
             self.install_data = '/etc/jsnapy'
             
         dir_path = self.install_data
-        mode = 0o777
+        mode = 0o700
         install.run(self)
         os.chmod(dir_path, mode)
         for root, dirs, files in os.walk(dir_path):
@@ -36,27 +36,31 @@ class OverrideInstall(install):
                 os.chmod(os.path.join(root, directory), mode)
             for fname in files:
                 os.chmod(os.path.join(root, fname), mode)
-        config = ConfigParser.ConfigParser()
-        config.set('DEFAULT','config_file_path','/etc/jsnapy')
-        config.set('DEFAULT','snapshot_path', os.path.join(dir_path,'snapshots'))
-        config.set('DEFAULT','test_file_path',os.path.join(dir_path,'testfiles'))
         
-        default_config_location = "/etc/jsnapy/jsnapy.cfg"
-        if os.path.isfile(default_config_location):
-            with open(default_config_location,'w') as cfgfile:
-                comment = ( '# This file can be overwritten\n'
-                            '# It contains default path for\n'
-                            '# config file, snapshots and testfiles\n'
-                            '# If required, overwrite the path with your path\n'
-                            '# config_file_path: path of main config file\n'
-                            '# snapshot_path : path of snapshot file\n'
-                            '# test_file_path: path of test file\n\n'
-                            )
-                cfgfile.write(comment)
-                config.write(cfgfile)
-        else:
-            raise Exception('jsnapy.cfg not found at /etc/jsnapy')
+        os.environ['JSNAPY_HOME'] = '/etc/jsnapy'
 
+        if dir_path != '/etc/jsnapy':
+            config = ConfigParser.ConfigParser()
+            config.set('DEFAULT','config_file_path','/etc/jsnapy')
+            config.set('DEFAULT','snapshot_path', os.path.join(dir_path,'snapshots'))
+            config.set('DEFAULT','test_file_path',os.path.join(dir_path,'testfiles'))
+            
+            default_config_location = "/etc/jsnapy/jsnapy.cfg"
+            if os.path.isfile(default_config_location):
+                with open(default_config_location,'w') as cfgfile:
+                    comment = ( '# This file can be overwritten\n'
+                                '# It contains default path for\n'
+                                '# config file, snapshots and testfiles\n'
+                                '# If required, overwrite the path with your path\n'
+                                '# config_file_path: path of main config file\n'
+                                '# snapshot_path : path of snapshot file\n'
+                                '# test_file_path: path of test file\n\n'
+                                )
+                    cfgfile.write(comment)
+                    config.write(cfgfile)
+            else:
+                raise Exception('jsnapy.cfg not found at /etc/jsnapy')
+        
 
 req_lines = [line.strip() for line in open(
     'requirements.txt').readlines()]

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ class OverrideInstall(install):
             self.install_data = '/etc/jsnapy'
             
         dir_path = self.install_data
-        mode = 0o700
+        mode = 0o777
         install.run(self)
         os.chmod(dir_path, mode)
         for root, dirs, files in os.walk(dir_path):
@@ -36,12 +36,10 @@ class OverrideInstall(install):
                 os.chmod(os.path.join(root, directory), mode)
             for fname in files:
                 os.chmod(os.path.join(root, fname), mode)
-        
-        os.environ['JSNAPY_HOME'] = '/etc/jsnapy'
-
+    
         if dir_path != '/etc/jsnapy':
             config = ConfigParser.ConfigParser()
-            config.set('DEFAULT','config_file_path','/etc/jsnapy')
+            config.set('DEFAULT','config_file_path',dir_path)
             config.set('DEFAULT','snapshot_path', os.path.join(dir_path,'snapshots'))
             config.set('DEFAULT','test_file_path',os.path.join(dir_path,'testfiles'))
             
@@ -94,7 +92,7 @@ setup(name="jsnapy",
       scripts=['tools/jsnap2py'],
       zip_safe=False,
       install_requires=install_reqs,
-      data_files=[("", ['lib/jnpr/jsnapy/logging.yml']),
+      data_files=[('/etc/jsnapy', ['lib/jnpr/jsnapy/logging.yml']),
                   ('samples', example_files),
                   ('/etc/jsnapy', ['lib/jnpr/jsnapy/jsnapy.cfg']),
                   ('testfiles', ['testfiles/README']),


### PR DESCRIPTION
#94 - 

1. The default location for jsnapy.cfg and logging.yml is /etc/jsnapy. User can change the default lookup location for jsnapy.cfg by setting JSNAPY_HOME environment variable. Alternatively, one can keep custom jsnapy.cfg and logging.yml at ~/.jsnapy also. Lookup order followed is: JSNAPY_HOME -> ~/.jsnapy -> /etc/jsnapy
2. Location of all the other custom configuration files parked at /etc/jsnapy can now be specified at the installation time. Doing so will modify the jsnapy.cfg file at /etc/jsnapy

#107 - Added option for the user to specify the default directory for snapshots, testfiles and custom configuration file directories during installation

Installation via pip:
`sudo pip install dist/jsnapy-x.x.tar.gz  --install-option="--install-data=~/Desktop/test_inst"`

Installation via setup.py:
`sudo python setup.py install --install-data ~/Desktop/test_inst`

If --install-data is not specified then the location of snapshots, testfiles directories and logging.yml defaults to /etc/jsnapy
