### PR TITLE
Port mult overlap -- Fix #138, Fix #136, Fix #126

### DIFF
--- a/lib/jnpr/jsnapy/jsnapy.py
+++ b/lib/jnpr/jsnapy/jsnapy.py
@@ -14,7 +14,6 @@ import sys
 import textwrap
 from copy import deepcopy
 from threading import Thread
-# from multiprocessing.dummy import Pool as ThreadPool
 
 import yaml
 from jnpr.jsnapy import get_path, version

--- a/lib/jnpr/jsnapy/jsnapy.py
+++ b/lib/jnpr/jsnapy/jsnapy.py
@@ -5,26 +5,30 @@
 # All rights reserved.
 #
 
-import os
-import sys
-import yaml
-import Queue
+import argparse
 import getpass
 import logging
+import os
+import Queue
+import sys
 import textwrap
-import argparse
-import colorama
-import setup_logging
-from threading import Thread
 from copy import deepcopy
-from jnpr.jsnapy.snap import Parser
+from threading import Thread
+# from multiprocessing.dummy import Pool as ThreadPool
+
+import yaml
+from jnpr.jsnapy import get_path, version
 from jnpr.jsnapy.check import Comparator
 from jnpr.jsnapy.notify import Notification
 from jnpr.junos import Device
 from jnpr.jsnapy import version
 from jnpr.jsnapy import get_path
 from jnpr.jsnapy.operator import Operator
+from jnpr.jsnapy.snap import Parser
 from jnpr.junos.exception import ConnectAuthError
+
+import colorama
+import setup_logging
 
 logging.getLogger("paramiko").setLevel(logging.WARNING)
 
@@ -401,6 +405,7 @@ class SnapAdmin:
                 del key_value[v]
         return key_value
 
+
     def login(self, output_file):
         """
         Extract device information from main config file. Stores device information and call connect function,
@@ -410,36 +415,38 @@ class SnapAdmin:
         """
         self.host_list = []
         if self.args.hostname is None:
+            host_dict={}
             try:
-                k = self.main_file['hosts'][0]
+                hosts_val = self.main_file['hosts']
             except KeyError as ex:
                 self.logger.error(colorama.Fore.RED +
-                                  "\nERROR occurred !! Hostname not given properly %s" %
-                                  str(ex),
-                                  extra=self.log_detail)
+                "\nERROR occurred !! Hostname not given properly %s" %
+                str(ex),
+                extra=self.log_detail)
                 #raise Exception(ex)
             except Exception as ex:
                 self.logger.error(colorama.Fore.RED +
-                                  "\nERROR occurred !! %s" %
-                                  str(ex),
-                                  extra=self.log_detail)
+                "\nERROR occurred !! %s" %
+                str(ex),
+                extra=self.log_detail)
                 #raise Exception(ex)
             else:
                 # when group of devices are given, searching for include keyword in
                 # hosts in main.yaml file
-                if k.__contains__('include'):
-                    file_tag = k['include']
-                    if os.path.isfile(file_tag):
-                        lfile = file_tag
+                first_entry = hosts_val[0]
+                if 'include' in first_entry:
+                    devices_file_name = first_entry['include']
+                    if os.path.isfile(devices_file_name):
+                        lfile = devices_file_name
                     else:
                         lfile = os.path.join(
-                            get_path(
-                                'DEFAULT',
-                                'test_file_path'),
-                            file_tag)
+                                    get_path(
+                                        'DEFAULT',
+                                        'test_file_path'),
+                                    devices_file_name)
                     login_file = open(lfile, 'r')
                     dev_file = yaml.load(login_file)
-                    gp = k.get('group', 'all')
+                    gp = first_entry.get('group', 'all')
 
                     dgroup = [i.strip().lower() for i in gp.split(',')]
                     for dgp in dev_file:
@@ -447,63 +454,56 @@ class SnapAdmin:
                             for val in dev_file[dgp]:
                                 hostname = val.keys()[0]
                                 self.log_detail = {'hostname': hostname}
-                                self.host_list.append(hostname)
-                                key_value = deepcopy(val.get(hostname))
-                                if val.get(hostname) is not None and 'username' in val.get(
-                                        hostname).keys():
-                                    username = val.get(
-                                        hostname).get('username')
-                                else:
-                                    username = self.args.login
-                                if val.get(hostname) is not None and 'passwd' in val.get(
-                                        hostname).keys():
-                                    password = val.get(hostname).get('passwd')
-                                else:
-                                    password = self.args.passwd
-                                    # if self.args.passwd is not None else
-                                    # getpass.getpass("\nEnter Password for
-                                    # username: %s " %username)
-                                key_value = self.get_values(key_value)
-                                t = Thread(
-                                    target=self.connect,
-                                    args=(
-                                        hostname,
-                                        username,
-                                        password,
-                                        output_file
-                                    ),
-                                    kwargs= key_value
-                                )
-                                t.start()
-                                t.join()
-            # login credentials are given in main config file, can connect to only
-            # one device
+                                if val.get(hostname) is not None and hostname not in host_dict:
+                                    host_dict[hostname] = deepcopy(val.get(hostname))
+                                    self.host_list.append(hostname)
+                # login credentials are given in main config file, can connect to multiple devices
                 else:
-                    key_value = deepcopy(k)
-
-                    try:
-                        hostname = k['device']
-                        self.log_detail = {'hostname': hostname}
-                    except KeyError as ex:
-                        self.logger.error(
+                    #key_value = deepcopy(k)
+                    for host in hosts_val:
+                        try:
+                            hostname = host['device']
+                            self.log_detail = {'hostname': hostname}
+                        except KeyError as ex:
+                            self.logger.error(
                             colorama.Fore.RED +
                             "ERROR!! KeyError 'device' key not found",
                             extra=self.log_detail)
-                        #raise Exception(ex)
-                    except Exception as ex:
-                        self.logger.error(
+                            #raise Exception(ex)
+                        except Exception as ex:
+                            self.logger.error(
                             colorama.Fore.RED +
                             "ERROR!! %s" %
                             ex,
                             extra=self.log_detail)
-                        #raise Exception(ex)
-                    else:
-                        username = k.get('username') or self.args.login
-                        password = k.get('passwd') or self.args.passwd
-                        self.host_list.append(hostname)
-                        key_value= self.get_values(key_value)
-                        self.connect(hostname, username, password, output_file, **key_value)
+                            #raise Exception(ex)
+                        else:
+                            if hostname not in host_dict:
+                                self.host_list.append(hostname)
+                                # host.pop('device')
+                                host_dict[hostname] = deepcopy(host)
 
+            for hostname, key_value in host_dict.iteritems():
+                #The file config takes precedence over cmd line params -- no changes made
+                username = self.args.login or key_value.get('username') 
+                password = self.args.passwd or key_value.get('passwd') 
+                #if --port arg is given on the cmd then that takes precedence                
+                port = self.args.port
+                if port is not None:
+                    key_value['port'] = port
+                key_value = self.get_values(key_value)
+                t = Thread(
+                    target=self.connect,
+                    args=(
+                        hostname,
+                        username,
+                        password,
+                        output_file
+                    ),
+                    kwargs= key_value
+                )
+                t.start()
+                t.join()
         # login credentials are given from command line
         else:
             hostname = self.args.hostname
@@ -670,10 +670,10 @@ class SnapAdmin:
     ############################### functions to support module ##############
 
     def multiple_device_details(
-            self, host, config_data, pre_name, action, post_name):
+            self, hosts, config_data, pre_name, action, post_name):
         """
         Called when multiple devices are given in config file
-        :param host: hostname
+        :param hosts: List of devices or a includes a file
         :param config_data: data of main config file
         :param pre_name: pre snapshot filename or file tag
         :param action: action to be taken, snap, snapcheck, check
@@ -682,47 +682,78 @@ class SnapAdmin:
         """
         res_obj = []
         self.host_list = []
-        login_file = host['include']
-        login_file = login_file if os.path.isfile(
-            host.get('include')) else os.path.join(
-            get_path(
-                'DEFAULT',
-                'test_file_path'),
-            login_file)
-        login_file = open(login_file, 'r')
-        dev_file = yaml.load(login_file)
-        gp = host.get('group', 'all')
-        dgroup = [i.strip().lower() for i in gp.split(',')]
-        for dgp in dev_file:
-            if dgroup[0].lower() == 'all' or dgp.lower() in dgroup:
-                for val in dev_file[dgp]:
-                    hostname = val.keys()[0]
-                    self.host_list.append(hostname)
-                    self.log_detail['hostname'] = hostname
-                    username = val.get(hostname).get('username')
-                    password = val.get(hostname).get('passwd')
-                    key_value = val.get(hostname)
-                    key_value= self.get_values(key_value)
-                    t = Thread(
-                        target=self.connect,
-                        args=(
-                            hostname,
-                            username,
-                            password,
-                            pre_name,
-                            config_data,
-                            action,
-                            post_name),
-                        kwargs= key_value
-                    )
-                    t.start()
-                    if action == "snap":
-                        res_obj.append(self.snap_q.get())
-                    elif action in ["snapcheck", "check"]:
-                        res_obj.append(self.q.get())
-                    else:
-                        res_obj.append(None)
-                    t.join()
+        host_dict={}
+
+        first_entry = hosts[0]
+        if 'include' in first_entry:
+            devices_file_name = first_entry['include']
+            if os.path.isfile(devices_file_name):
+                lfile = devices_file_name
+            else:
+                lfile = os.path.join(
+                            get_path(
+                                'DEFAULT',
+                                'test_file_path'),
+                            devices_file_name)
+            login_file = open(lfile, 'r')
+            dev_file = yaml.load(login_file)
+            gp = first_entry.get('group', 'all')
+
+            dgroup = [i.strip().lower() for i in gp.split(',')]
+            for dgp in dev_file:
+                if dgroup[0].lower() == 'all' or dgp.lower() in dgroup:
+                    for val in dev_file[dgp]:
+                        hostname = val.keys()[0]
+                        self.log_detail = {'hostname': hostname}
+                        if val.get(hostname) is not None and hostname not in host_dict:
+                            host_dict[hostname] = deepcopy(val.get(hostname))
+                            self.host_list.append(hostname)
+        else:
+            for host in hosts:
+                try:
+                    hostname = host['device']
+                    self.log_detail = {'hostname': hostname}
+                except KeyError as ex:
+                    self.logger.error(
+                    colorama.Fore.RED +
+                    "ERROR!! KeyError 'device' key not found",
+                    extra=self.log_detail)
+                except Exception as ex:
+                    self.logger.error(
+                    colorama.Fore.RED +
+                    "ERROR!! %s" %
+                    ex,
+                    extra=self.log_detail)
+                else:
+                    if hostname not in host_dict:
+                        self.host_list.append(hostname)
+                        host_dict[hostname] = deepcopy(host)
+
+        for hostname, key_value in host_dict.iteritems():
+            username = key_value.get('username')
+            password = key_value.get('passwd')
+            key_value = self.get_values(key_value)
+            t = Thread(
+                target=self.connect,
+                args=(
+                    hostname,
+                    username,
+                    password,
+                    pre_name,
+                    config_data,
+                    action,
+                    post_name),
+                kwargs= key_value
+            )
+            t.start()
+            if action == "snap":
+                res_obj.append(self.snap_q.get())
+            elif action in ["snapcheck", "check"]:
+                res_obj.append(self.q.get())
+            else:
+                res_obj.append(None)
+            t.join()
+
         return res_obj
 
     def extract_data(
@@ -767,9 +798,9 @@ class SnapAdmin:
                     None,
                     None,
                     action)
-            if host.__contains__('include'):
+            if host.__contains__('include') or len(config_data.get('hosts'))>1:
                 res_obj = self.multiple_device_details(
-                    host,
+                    config_data.get('hosts'),
                     config_data,
                     pre_name,
                     action,

--- a/tests/unit/configs/devices_with_port.yml
+++ b/tests/unit/configs/devices_with_port.yml
@@ -1,0 +1,37 @@
+MX:                      # for multiple hostnames assuming login credentials are same for all
+  - 10.209.16.203:
+      username: abc
+      passwd: def
+      port: 100
+  - 10.209.16.204:
+      username: abc
+      passwd: def
+      port: 101
+  - 10.209.16.205:
+      username: abc
+      passwd: def
+      port: 102
+
+EX:                      # for multiple hostnames assuming login credentials are same for all
+  - 10.209.16.206:
+      username: abc
+      passwd: def
+      port: 103
+  - 10.209.16.212:
+      username: abc
+      passwd: def
+      port: 104
+
+QFX:                      # for multiple hostnames assuming login credentials are same for all
+  - 10.209.16.214:
+      username: abc
+      passwd: def
+      port: 105
+  - 10.209.16.221:
+      username: abc
+      passwd: def
+      port: 106
+  - 10.209.16.222:
+      username: abc
+      passwd: def
+      port: 107

--- a/tests/unit/configs/main2_with_port.yml
+++ b/tests/unit/configs/main2_with_port.yml
@@ -1,0 +1,10 @@
+hosts:
+  - include: devices_with_port.yml
+    group: mx  
+tests:
+  - delta.yml
+sqlite:
+  - store_in_sqlite: no
+    check_from_sqlite: no
+    database_name: jbb.db
+    compare: 0,1

--- a/tests/unit/configs/main_6.yml
+++ b/tests/unit/configs/main_6.yml
@@ -1,0 +1,19 @@
+# for one device, can be given like this:
+hosts:
+  - device: 10.216.193.114
+    username : abc
+    passwd: xyz
+  - device: 10.216.193.115
+    username : abc
+    passwd: xyz
+  - device: 10.216.193.116
+    username : abc
+    passwd: xyz
+tests:
+  - delta.yml
+sqlite:
+  - store_in_sqlite: no
+    check_from_sqlite: yes
+    database_name: jbb.db
+    compare: 0,1
+

--- a/tests/unit/configs/main_with_port.yml
+++ b/tests/unit/configs/main_with_port.yml
@@ -1,0 +1,15 @@
+# for one device, can be given like this:
+hosts:
+  - device: 10.216.193.114
+    username : abc
+    passwd: xyz
+    port: 44
+tests:
+  - delta.yml
+sqlite:
+  - store_in_sqlite: no
+    check_from_sqlite: no
+    database_name: jbb.db
+    compare: 0,1
+
+

--- a/tests/unit/test_jsnapy.py
+++ b/tests/unit/test_jsnapy.py
@@ -68,7 +68,7 @@ class TestSnapAdmin(unittest.TestCase):
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         js = SnapAdmin()
         conf_file = os.path.join(os.path.dirname(__file__),
-                                 'configs', 'main2.yml')
+                                 'configs', 'main1.yml')
         config_file = open(conf_file, 'r')
         js.main_file = yaml.load(config_file)
         js.login("snap_1")

--- a/tests/unit/test_jsnapy.py
+++ b/tests/unit/test_jsnapy.py
@@ -2,7 +2,7 @@ import unittest
 import yaml
 import os
 from jnpr.jsnapy.jsnapy import SnapAdmin
-from mock import patch, MagicMock
+from mock import patch, MagicMock, call
 from contextlib import nested
 from nose.plugins.attrib import attr
 import argparse
@@ -43,12 +43,19 @@ class TestSnapAdmin(unittest.TestCase):
             diff=False, file=None, hostname=None, login=None, passwd=None, port=None, post_snapfile=None, pre_snapfile=None, snap=False, snapcheck=False, verbosity=None, version=False)
         js = SnapAdmin()
         conf_file = os.path.join(os.path.dirname(__file__),
-                                 'configs', 'main_1.yml')
+                                 'configs', 'main_6.yml')
         config_file = open(conf_file, 'r')
         js.main_file = yaml.load(config_file)
         js.login("snap_1")
-        hosts = ['10.216.193.114']
+        expected_calls_made = [call('10.216.193.114','abc','xyz','snap_1'),
+                                call('10.216.193.115','abc','xyz','snap_1'), 
+                                call('10.216.193.116','abc','xyz','snap_1'),
+                                ]  
+        
+        hosts = ['10.216.193.114','10.216.193.115','10.216.193.116']
         self.assertEqual(js.host_list, hosts)
+        mock_connect.assert_has_calls(expected_calls_made, any_order=True)
+        
 
 
     @patch('argparse.ArgumentParser.exit')
@@ -61,12 +68,25 @@ class TestSnapAdmin(unittest.TestCase):
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         js = SnapAdmin()
         conf_file = os.path.join(os.path.dirname(__file__),
-                                 'configs', 'main1.yml')
+                                 'configs', 'main2.yml')
         config_file = open(conf_file, 'r')
         js.main_file = yaml.load(config_file)
         js.login("snap_1")
         hosts = ['10.209.16.203', '10.209.16.204', '10.209.16.205']
         self.assertEqual(js.host_list, hosts)
+
+        #extending the test to check for device overlap among groups
+        js.main_file['hosts'][0]['group']='MX, EX'
+        expected_calls_made = [call('10.209.16.203','abc','def','snap_1'),
+                                call('10.209.16.204','abc','def','snap_1'), 
+                                call('10.209.16.205','abc','def','snap_1'),
+                                call('10.209.16.206','abc','def','snap_1'),
+                                call('10.209.16.212','abc','def','snap_1'),
+                                ]   
+        
+        js.login("snap_1")
+        mock_connect.assert_has_calls(expected_calls_made, any_order=True)
+
 
     @patch('argparse.ArgumentParser.exit')
     @patch('jnpr.jsnapy.jsnapy.Device')
@@ -574,6 +594,91 @@ class TestSnapAdmin(unittest.TestCase):
         js.args.post_snapfile = "mock_snap2"
         js.get_hosts()
         self.assertEqual(js.db, self.db)   
+    @patch('jnpr.jsnapy.SnapAdmin.connect')
+    def test_port_without_include(self,mock_connect):
+        #this test case is for scenarios when devices are mentioned in the cfg file itself
+        js = SnapAdmin()
+        # js.args.snap = True  
+        js.args.hostname = None
+
+        conf_file = os.path.join(os.path.dirname(__file__),
+                                 'configs', 'main_with_port.yml')
+        config_file = open(conf_file, 'r')
+        js.main_file = yaml.load(config_file)
+        js.login("snap_1")
+        hosts = ['10.216.193.114']
+        self.assertEqual(js.host_list, hosts)
+        mock_connect.assert_called_with('10.216.193.114','abc','xyz','snap_1',port=44)
+        
+        #adding another device in the config dictionary 
+        #and checking the precedence b/w cmd and config params
+        js.main_file['hosts'].append({'device':'10.216.193.115',
+                                    'username':'abc',
+                                    'passwd':'xyz',
+                                    'port':45})
+        js.args.port=100
+        
+        
+        expected_calls_made = [call('10.216.193.114','abc','xyz','snap_1',port=100),
+                                call('10.216.193.115','abc','xyz','snap_1',port=100)]   
+        js.login("snap_1")
+        mock_connect.assert_has_calls(expected_calls_made, any_order=True)
+        
+        #deleting the port paramater from the config file and keeping the port param on cmd args
+        for host in js.main_file['hosts']: 
+            if 'port' in host:
+                del host['port']
+           
+        js.login("snap_1")
+        mock_connect.assert_has_calls(expected_calls_made, any_order=True)
+        
+        #deleting the cmd line port param
+        expected_calls_made = [call('10.216.193.114','abc','xyz','snap_1'),
+                                call('10.216.193.115','abc','xyz','snap_1')]   
+        js.args.port=None
+        js.login("snap_1")
+        mock_connect.assert_has_calls(expected_calls_made, any_order=True)
+
+   
+    @patch('jnpr.jsnapy.jsnapy.get_path')
+    @patch('jnpr.jsnapy.SnapAdmin.connect')
+    def test_port_with_include(self,mock_connect,mock_path):
+        #this test case is for scenarios when devices are included using some other file
+        js = SnapAdmin()
+        js.args.snap = True  
+        js.args.hostname = None
+        mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
+
+        conf_file = os.path.join(os.path.dirname(__file__),
+                                 'configs', 'main2_with_port.yml')
+        config_file = open(conf_file, 'r')
+        js.main_file = yaml.load(config_file)
+        
+        hosts = ['10.209.16.203','10.209.16.204','10.209.16.205']
+        expected_calls_made = [call('10.209.16.203','abc','def','snap_1',port=100),
+                                call('10.209.16.204','abc','def','snap_1',port=101), 
+                                call('10.209.16.205','abc','def','snap_1',port=102)] 
+        
+        js.login("snap_1")
+        
+        self.assertEqual(js.host_list, hosts)
+        mock_connect.assert_has_calls(expected_calls_made, any_order=True)
+        #    mock_connect.assert_called_with('10.216.193.114','abc','xyz','snap_1',port=44)
+        
+        
+        #Adding the cmd-line port param and checking the precedence b/w cmd and config params
+        js.args.port=55
+        expected_calls_made = [call('10.209.16.203','abc','def','snap_1',port=55),
+                                call('10.209.16.204','abc','def','snap_1',port=55), 
+                                call('10.209.16.205','abc','def','snap_1',port=55)]   
+        js.login("snap_1")
+
+        mock_connect.assert_has_calls(expected_calls_made, any_order=True)
+
+    
+        
+           
+        
 
 with nested(
     patch('sys.exit'),


### PR DESCRIPTION
Fix #138
Fix #136 
Fix #126

Changes made:

Login function modified to aggregate host configuration in a dictionary and then called connect() using the same.
Added various tests for port param bug.
Modified tests for checking device overlap and multiple device specification without the use of 'include' file.
Multiple device support for module also