### PR TITLE
Support for stored snapshot -- Fix #132

### DIFF
--- a/lib/jnpr/jsnapy/jsnapy.py
+++ b/lib/jnpr/jsnapy/jsnapy.py
@@ -110,6 +110,10 @@ class SnapAdmin:
             "-f", "--file",
             help="config file to take snapshot",
             type=str)
+        self.parser.add_argument(
+            "--local",
+            help="stored snapshot name to run snapcheck on",
+            type=str)
         self.parser.add_argument("-t", "--hostname", help="hostname", type=str)
         self.parser.add_argument(
             "-p",
@@ -609,7 +613,7 @@ class SnapAdmin:
         if config_data is None:
             config_data = self.main_file
 
-        if self.args.snap is True or self.args.snapcheck is True or action in [
+        if self.args.snap is True or ( self.args.snapcheck is True and self.args.local is None ) or action in [
                 "snap", "snapcheck"]:
             self.logger.info(
                 colorama.Fore.BLUE +
@@ -659,6 +663,10 @@ class SnapAdmin:
                 dev.close()
         if self.args.check is True or self.args.snapcheck is True or self.args.diff is True or action in [
                 "check", "snapcheck"]:
+            
+            if self.args.local is not None:
+                output_file = self.args.local  
+
             res = self.get_test(
                 config_data,
                 hostname,

--- a/lib/jnpr/jsnapy/jsnapy.py
+++ b/lib/jnpr/jsnapy/jsnapy.py
@@ -922,7 +922,7 @@ class SnapAdmin:
         :param data: either main config file or string containing details of main config file
         :param pre_file: pre snap file, either complete filename or file tag
         :param dev: device object
-        :return: return object of testop.Operator containing test details
+        :return: return list of object of testop.Operator containing test details or list of dictionary of object of testop.Operator containing test details for each stored snapshot
         """
         if file_name is None:
             file_name = "snap_temp"

--- a/lib/jnpr/jsnapy/jsnapy.py
+++ b/lib/jnpr/jsnapy/jsnapy.py
@@ -617,7 +617,7 @@ class SnapAdmin:
         if 'local' in config_data:
             self.args.local = True
         
-        if (self.args.snap is True or action is "snap") or ( (self.args.snapcheck is True or action is "snapcheck") and self.args.local is None ):
+        if (self.args.snap is True or action is "snap") or ( (self.args.snapcheck is True or action is "snapcheck") and self.args.local is not True ):
             self.logger.info(
                 colorama.Fore.BLUE +
                 "Connecting to device %s ................", hostname, extra=self.log_detail)

--- a/lib/jnpr/jsnapy/jsnapy.py
+++ b/lib/jnpr/jsnapy/jsnapy.py
@@ -688,13 +688,13 @@ class SnapAdmin:
                     "ERROR!! Unable to parse 'local' option", extra=self.log_detail)
                 return
 
-        if not flag:
-           res = self.get_test(
-                    config_data,
-                    hostname,
-                    output_file,
-                    post_snap,
-                    action)     
+            if not flag:
+                res = self.get_test(
+                            config_data,
+                            hostname,
+                            output_file,
+                            post_snap,
+                            action)     
                 
         return res
 

--- a/lib/jnpr/jsnapy/jsnapy.py
+++ b/lib/jnpr/jsnapy/jsnapy.py
@@ -613,6 +613,9 @@ class SnapAdmin:
         if config_data is None:
             config_data = self.main_file
 
+        if 'local' in config_data:
+            self.args.local = config_data['local']
+
         if self.args.snap is True or ( self.args.snapcheck is True and self.args.local is None ) or action in [
                 "snap", "snapcheck"]:
             self.logger.info(
@@ -664,15 +667,35 @@ class SnapAdmin:
         if self.args.check is True or self.args.snapcheck is True or self.args.diff is True or action in [
                 "check", "snapcheck"]:
             
-            if self.args.local is not None:
-                output_file = self.args.local  
+            flag = False
+            if self.args.local is not None and type(self.args.local) is list:
+                output_file = self.args.local
+                res = {}
+                for local_snap in output_file:
+                    ret_obj = self.get_test(
+                                config_data,
+                                hostname,
+                                local_snap,
+                                post_snap,
+                                action)
+                    res[local_snap] = ret_obj
+                flag = True
+            elif self.args.local is not None and type(self.args.local) is str:
+                output_file = self.args.local
+            elif self.args.local is not None:
+                self.logger.error(
+                    colorama.Fore.RED +
+                    "ERROR!! Unable to parse 'local' option", extra=self.log_detail)
+                return
 
-            res = self.get_test(
-                config_data,
-                hostname,
-                output_file,
-                post_snap,
-                action)
+        if not flag:
+           res = self.get_test(
+                    config_data,
+                    hostname,
+                    output_file,
+                    post_snap,
+                    action)     
+                
         return res
 
     ############################### functions to support module ##############

--- a/tests/unit/configs/main_local_snapcheck.yml
+++ b/tests/unit/configs/main_local_snapcheck.yml
@@ -1,0 +1,17 @@
+# for one device, can be given like this:
+hosts:
+  - device: 10.216.193.114
+    username : abc
+    passwd: xyz
+tests:
+  - delta.yml
+local:
+  - PRE
+  - PRE_42
+  - PRE_314
+sqlite:
+  - store_in_sqlite: no
+    check_from_sqlite: no
+    database_name: jbb.db
+    compare: 0,1
+


### PR DESCRIPTION
Fix #132
Added support for stored snapshot.

Usage:
1. First one needs to create a snapshot
`jsnapy --snap STORED -f config.yml`
2. To run snapcheck on this stored snapshot from command line, use `--local` parameter
`jsnapy --snapcheck STORED -f config.yml --local`
3. One can also specify the stored snapshots' name in the configuration file as follows:
```yaml
hosts:
  - device: 10.216.193.114
    username : abc
    passwd: xyz
tests:
  - delta.yml
local:
  - STORED
  - STORED_42
  - STORED_314
sqlite:
  - store_in_sqlite: no
    check_from_sqlite: no
    database_name: jbb.db
    compare: 0,1
```

Things to Note:
1. The devices and the various commands passed in the configuration file passed should match with the ones passed to the tool while capturing the snapshot. One can modify the various test operators.
2. If a user wants to run local snapcheck on his own xml file, he need to modify the name of that xml to the format given below, place it in the snapshots directory and modify the configuration file accordingly.
`hostname_snapname_command.xml`
or
`hostname_snapname_rpc.xml`

For module version:
1. One needs to pass additional parameter `local=True` while calling snapcheck() to use local snapcheck. The snapname passed is considered as the local snapshot to run snapcheck on, just like the command line. This parameter is not required if the configuration file contains the list of snapshot names as above.
2. The configuration file support for `local` as expected is also baked in.
3. Return Types:

1. If one specifies the `local` keyword in the configuration file, then the snapcheck() function returns a list of dictionary, where the dictionary is keyed with the various snapnames passed and the value is an Operator object which contains the test details is returned.
2. In every other case, a list of Operator object which contains the test details is returned