### PR TITLE
Issues with /etc/jsnapy -- #94 & #107

### DIFF
--- a/lib/jnpr/jsnapy/__init__.py
+++ b/lib/jnpr/jsnapy/__init__.py
@@ -9,11 +9,29 @@ import os
 import colorama
 colorama.init(autoreset=True)
 
+def get_config_location(file='jsnapy.cfg'):
+    p_locations = []
+    if 'JSNAPY_HOME' in os.environ:
+        p_locations = [os.environ['JSNAPY_HOME']]   
+    p_locations.extend([os.path.join(os.path.expanduser('~'),'.jsnapy'),'/etc/jsnapy'])
+    
+    for loc in p_locations:
+        possible_location =  os.path.join(loc,file)
+        if os.path.isfile(possible_location):
+            return loc
+    return None
+    
 
 def get_path(section, value):
-    config = ConfigParser.ConfigParser({'config_file_path': '/etc/jsnapy', 'snapshot_path': '/etc/jsnapy/snapshots',
-                                        'test_file_path': '/etc/jsnapy/testfiles', 'log_file_path': '/etc/logs/jsnapy'})
-    config.read(os.path.join('/etc', 'jsnapy', 'jsnapy.cfg'))
+    # config = ConfigParser.ConfigParser({'config_file_path': '/usr/local/share/', 'snapshot_path': '/usr/local/share/snapshots',
+    #                                     'test_file_path': '/usr/local/share/testfiles', 'log_file_path': '/var/log/jsnapy'})
+    config = ConfigParser.ConfigParser()
+    
+    config_location = get_config_location()
+    if config_location is None:
+        raise Exception('Config file not found')
+    config_location = os.path.join(config_location,'jsnapy.cfg')
+    config.read(config_location)
     path = config.get(section, value)
     return path
 

--- a/lib/jnpr/jsnapy/jsnapy.py
+++ b/lib/jnpr/jsnapy/jsnapy.py
@@ -16,12 +16,11 @@ from copy import deepcopy
 from threading import Thread
 
 import yaml
-from jnpr.jsnapy import get_path, version
+from jnpr.jsnapy import get_path, version, get_config_location
 from jnpr.jsnapy.check import Comparator
 from jnpr.jsnapy.notify import Notification
 from jnpr.junos import Device
 from jnpr.jsnapy import version
-from jnpr.jsnapy import get_path
 from jnpr.jsnapy.operator import Operator
 from jnpr.jsnapy.snap import Parser
 from jnpr.junos.exception import ConnectAuthError
@@ -290,6 +289,10 @@ class SnapAdmin:
         read device details and connect them. Also checks sqlite key to check if user wants to
         create database for snapshots
         """
+        self.logger.debug(colorama.Fore.BLUE +
+                "jsnapy.cfg file location used : %s" %
+                get_config_location(), extra=self.log_detail)
+                
         if self.args.pre_snapfile is not None:
             output_file = self.args.pre_snapfile
         elif self.args.snapcheck is True and self.args.pre_snapfile is None:

--- a/lib/jnpr/jsnapy/setup_logging.py
+++ b/lib/jnpr/jsnapy/setup_logging.py
@@ -8,11 +8,13 @@
 import os
 import yaml
 import logging.config
+from jnpr.jsnapy import get_config_location
 
 
 def setup_logging(
         default_path='logging.yml', default_level=logging.INFO, env_key='LOG_CFG'):
-    path = os.path.join('/etc', 'jsnapy', default_path)
+    config_location = get_config_location('logging.yml')
+    path = os.path.join(config_location, default_path)
     value = os.getenv(env_key, None)
     if value:
         path = value

--- a/setup.py
+++ b/setup.py
@@ -5,17 +5,27 @@
 # All rights reserved.
 #
 
-import os
+import os,sys
+from os.path import expanduser
 from setuptools import setup, find_packages
 from setuptools.command.install import install
+import ConfigParser
 
 class OverrideInstall(install):
-
+   
     def run(self):
+        
+        for arg in sys.argv:
+            if '--install-data' in arg:
+                break
+        else:
+            self.install_data = '/etc/jsnapy'
+            
+        dir_path = self.install_data
         mode = 0o777
         install.run(self)
-        os.chmod('/etc/jsnapy', mode)
-        for root, dirs, files in os.walk('/etc/jsnapy'):
+        os.chmod(dir_path, mode)
+        for root, dirs, files in os.walk(dir_path):
             for directory in dirs:
                 os.chmod(os.path.join(root, directory), mode)
             for fname in files:
@@ -27,6 +37,35 @@ class OverrideInstall(install):
                 os.chmod(os.path.join(root, directory), mode)
             for fname in files:
                 os.chmod(os.path.join(root, fname), mode)
+        HOME = expanduser("~") #correct cross platform way to do it
+        home_folder = os.path.join(HOME,'.jsnapy')
+        if not os.path.isdir(home_folder):
+            os.mkdir(home_folder)
+            os.chmod(home_folder,mode)
+
+
+        if dir_path != '/etc/jsnapy':
+            config = ConfigParser.ConfigParser()
+            config.set('DEFAULT','config_file_path',dir_path)
+            config.set('DEFAULT','snapshot_path', os.path.join(dir_path,'snapshots'))
+            config.set('DEFAULT','test_file_path',os.path.join(dir_path,'testfiles'))
+            
+            default_config_location = "/etc/jsnapy/jsnapy.cfg"
+            if os.path.isfile(default_config_location):
+                with open(default_config_location,'w') as cfgfile:
+                    comment = ( '# This file can be overwritten\n'
+                                '# It contains default path for\n'
+                                '# config file, snapshots and testfiles\n'
+                                '# If required, overwrite the path with your path\n'
+                                '# config_file_path: path of main config file\n'
+                                '# snapshot_path : path of snapshot file\n'
+                                '# test_file_path: path of test file\n\n'
+                                )
+                    cfgfile.write(comment)
+                    config.write(cfgfile)
+            else:
+                raise Exception('jsnapy.cfg not found at /etc/jsnapy')
+        
 
 req_lines = [line.strip() for line in open(
     'requirements.txt').readlines()]
@@ -61,14 +100,12 @@ setup(name="jsnapy",
       zip_safe=False,
       install_requires=install_reqs,
       data_files=[('/etc/jsnapy', ['lib/jnpr/jsnapy/logging.yml']),
-                  ('/etc/jsnapy/samples', example_files),
+                  ('samples', example_files),
                   ('/etc/jsnapy', ['lib/jnpr/jsnapy/jsnapy.cfg']),
-                  ('/etc/jsnapy/testfiles',
-                   ['testfiles/README']),
-                  ('/etc/jsnapy/snapshots',
-                   ['snapshots/README']),
+                  ('testfiles', ['testfiles/README']),
+                  ('snapshots', ['snapshots/README']),
                   ('/var/log/jsnapy', log_files)
-                  ],
+                 ],
       cmdclass={'install': OverrideInstall},
       classifiers=[
           'Environment :: Console',


### PR DESCRIPTION
Fix #94 - 

1. The default location for jsnapy.cfg and logging.yml is /etc/jsnapy. User can change the default lookup location for jsnapy.cfg by setting JSNAPY_HOME environment variable. Alternatively, one can keep custom jsnapy.cfg and logging.yml at ~/.jsnapy also. Lookup order followed is: JSNAPY_HOME -> ~/.jsnapy -> /etc/jsnapy
2. Location of all the other custom configuration files parked at /etc/jsnapy can now be specified at the installation time. Doing so will modify the jsnapy.cfg file at /etc/jsnapy

Fix #107 -
Added option for the user to specify the default directory for snapshots, testfiles and custom configuration file directories during installation

Installation via pip:
`sudo pip install dist/jsnapy-x.x.tar.gz  --install-option="--install-data=~/Desktop/test_inst"`

Installation via setup.py:
`sudo python setup.py install --install-data ~/Desktop/test_inst`

If --install-data is not specified then the location of snapshots, testfiles directories and logging.yml defaults to /etc/jsnapy
