### PR TITLE
--dir option to change the lookup directory 

### DIFF
--- a/lib/jnpr/jsnapy/__init__.py
+++ b/lib/jnpr/jsnapy/__init__.py
@@ -24,7 +24,7 @@ def get_config_location(file='jsnapy.cfg'):
     return None
     
 
-def get_path(section, value, custom_dir=None):
+def get_path(section, value):
     # config = ConfigParser.ConfigParser({'config_file_path': '/usr/local/share/', 'snapshot_path': '/usr/local/share/snapshots',
     #                                     'test_file_path': '/usr/local/share/testfiles', 'log_file_path': '/var/log/jsnapy'})
     custom_dir = DirStore.custom_dir

--- a/lib/jnpr/jsnapy/__init__.py
+++ b/lib/jnpr/jsnapy/__init__.py
@@ -9,11 +9,29 @@ import os
 import colorama
 colorama.init(autoreset=True)
 
+def get_config_location(file='jsnapy.cfg'):
+    p_locations = []
+    if 'JSNAPY_HOME' in os.environ:
+        p_locations = [os.environ['JSNAPY_HOME']]   
+    p_locations.extend([os.path.join(os.path.expanduser('~'),'.jsnapy'),'/etc/jsnapy'])
+    
+    for loc in p_locations:
+        possible_location =  os.path.join(loc,file)
+        if os.path.isfile(possible_location):
+            return loc
+    return None
+    
 
 def get_path(section, value):
-    config = ConfigParser.ConfigParser({'config_file_path': '/etc/jsnapy', 'snapshot_path': '/etc/jsnapy/snapshots',
-                                        'test_file_path': '/etc/jsnapy/testfiles', 'log_file_path': '/etc/logs/jsnapy'})
-    config.read(os.path.join('/etc', 'jsnapy', 'jsnapy.cfg'))
+    # config = ConfigParser.ConfigParser({'config_file_path': '/usr/local/share/', 'snapshot_path': '/usr/local/share/snapshots',
+    #                                     'test_file_path': '/usr/local/share/testfiles', 'log_file_path': '/var/log/jsnapy'})
+    config = ConfigParser.ConfigParser()
+    
+    config_location = get_config_location()
+    if config_location is None:
+        raise Exception('Config file not found')
+    config_location = os.path.join(config_location,'jsnapy.cfg')
+    config.read(config_location)
     path = config.get(section, value)
     return path
 

--- a/lib/jnpr/jsnapy/__init__.py
+++ b/lib/jnpr/jsnapy/__init__.py
@@ -9,12 +9,14 @@ import os
 import colorama
 colorama.init(autoreset=True)
 
+class DirStore:
+    custom_dir = None
+        
 def get_config_location(file='jsnapy.cfg'):
     p_locations = []
     if 'JSNAPY_HOME' in os.environ:
         p_locations = [os.environ['JSNAPY_HOME']]   
     p_locations.extend([os.path.join(os.path.expanduser('~'),'.jsnapy'),'/etc/jsnapy'])
-    
     for loc in p_locations:
         possible_location =  os.path.join(loc,file)
         if os.path.isfile(possible_location):
@@ -22,17 +24,28 @@ def get_config_location(file='jsnapy.cfg'):
     return None
     
 
-def get_path(section, value):
+def get_path(section, value, custom_dir=None):
     # config = ConfigParser.ConfigParser({'config_file_path': '/usr/local/share/', 'snapshot_path': '/usr/local/share/snapshots',
     #                                     'test_file_path': '/usr/local/share/testfiles', 'log_file_path': '/var/log/jsnapy'})
-    config = ConfigParser.ConfigParser()
-    
-    config_location = get_config_location()
-    if config_location is None:
-        raise Exception('Config file not found')
-    config_location = os.path.join(config_location,'jsnapy.cfg')
-    config.read(config_location)
-    path = config.get(section, value)
+    custom_dir = DirStore.custom_dir
+    if custom_dir:
+        paths = {'config_file_path': '',
+                'snapshot_path': 'snapshots',
+                'test_file_path': 'testfiles'}
+        if custom_dir.startswith('~/'):
+            custom_dir = os.path.join(os.path.expanduser('~'),custom_dir[2:])
+        complete_paths = {}
+        for p in paths:
+            complete_paths[p]= os.path.join(custom_dir,paths[p])
+        path = complete_paths.get(value)
+    else:    
+        config = ConfigParser.ConfigParser()
+        config_location = get_config_location()
+        if config_location is None:
+            raise Exception('Config file not found')
+        config_location = os.path.join(config_location,'jsnapy.cfg')
+        config.read(config_location)
+        path = config.get(section, value)
     return path
 
 from jnpr.jsnapy.jsnapy import SnapAdmin

--- a/lib/jnpr/jsnapy/jsnapy.py
+++ b/lib/jnpr/jsnapy/jsnapy.py
@@ -118,7 +118,7 @@ class SnapAdmin:
             action="store_true",
             help="whether to run snapcheck on local snapshot")
         self.parser.add_argument(
-            "--dir",
+            "--folder",
             help="custom directory path for lookup",
             type=str)
         self.parser.add_argument("-t", "--hostname", help="hostname", type=str)
@@ -171,7 +171,7 @@ class SnapAdmin:
         self.db['first_snap_id'] = None
         self.db['second_snap_id'] = None
         
-        DirStore.custom_dir=self.args.dir
+        DirStore.custom_dir=self.args.folder
 
     def get_version(self):
         """
@@ -945,31 +945,31 @@ class SnapAdmin:
                             action))
             return res
 
-    def snap(self, data, file_name, dev=None, custom_dir=None):
+    def snap(self, data, file_name, dev=None, folder=None):
         """
         Function equivalent to --snap operator, for module version
         :param data: either main config file or string containing details of main config file
         :param file_name: snap file, either complete filename or file tag
         :param dev: device object
-        :param custom_dir: custom directory path to use for lookup
+        :param folder: custom directory path to use for lookup
         """
-        DirStore.custom_dir = custom_dir
+        DirStore.custom_dir = folder
         if isinstance(dev, Device):
             res = self.extract_dev_data(dev, data, file_name, "snap")
         else:
             res = self.extract_data(data, file_name, "snap")
         return res
 
-    def snapcheck(self, data, file_name=None, dev=None, local= False, custom_dir=None):
+    def snapcheck(self, data, file_name=None, dev=None, local= False, folder=None):
         """
         Function equivalent to --snapcheck operator, for module version
         :param data: either main config file or string containing details of main config file
         :param pre_file: pre snap file, either complete filename or file tag
         :param dev: device object
-        :param custom_dir: custom directory path to use for lookup
+        :param folder: custom directory path to use for lookup
         :return: return list of object of testop.Operator containing test details or list of dictionary of object of testop.Operator containing test details for each stored snapshot
         """
-        DirStore.custom_dir = custom_dir
+        DirStore.custom_dir = folder
         if file_name is None:
             file_name = "snap_temp"
             self.snap_del = True
@@ -979,17 +979,17 @@ class SnapAdmin:
             res = self.extract_data(data, file_name, "snapcheck")
         return res
 
-    def check(self, data, pre_file=None, post_file=None, dev=None, custom_dir=None):
+    def check(self, data, pre_file=None, post_file=None, dev=None, folder=None):
         """
         Function equivalent to --check operator, for module version
         :param data: either main config file or string containing details of main config file
         :param pre_file: pre snap file, either complete filename or file tag
         :param post_file: post snap file, either complete filename or file tag
         :param dev: device object
-        :param custom_dir: custom directory path to use for lookup
+        :param folder: custom directory path to use for lookup
         :return: return object of testop.Operator containing test details
         """
-        DirStore.custom_dir = custom_dir
+        DirStore.custom_dir = folder
         if isinstance(dev, Device):
             res = self.extract_dev_data(
                 dev,

--- a/lib/jnpr/jsnapy/jsnapy.py
+++ b/lib/jnpr/jsnapy/jsnapy.py
@@ -16,7 +16,7 @@ from copy import deepcopy
 from threading import Thread
 
 import yaml
-from jnpr.jsnapy import get_path, version, get_config_location
+from jnpr.jsnapy import get_path, version, get_config_location, DirStore
 from jnpr.jsnapy.check import Comparator
 from jnpr.jsnapy.notify import Notification
 from jnpr.junos import Device
@@ -117,6 +117,10 @@ class SnapAdmin:
             "--local",
             action="store_true",
             help="whether to run snapcheck on local snapshot")
+        self.parser.add_argument(
+            "--dir",
+            help="custom directory path for lookup",
+            type=str)
         self.parser.add_argument("-t", "--hostname", help="hostname", type=str)
         self.parser.add_argument(
             "-p",
@@ -166,6 +170,8 @@ class SnapAdmin:
         self.db['db_name'] = ""
         self.db['first_snap_id'] = None
         self.db['second_snap_id'] = None
+        
+        DirStore.custom_dir=self.args.dir
 
     def get_version(self):
         """
@@ -292,7 +298,10 @@ class SnapAdmin:
         self.logger.debug(colorama.Fore.BLUE +
                 "jsnapy.cfg file location used : %s" %
                 get_config_location(), extra=self.log_detail)
-                
+        self.logger.debug(colorama.Fore.BLUE +
+                "Configuration file location used : %s" %
+                get_path('DEFAULT', 'config_file_path'), extra=self.log_detail)
+                        
         if self.args.pre_snapfile is not None:
             output_file = self.args.pre_snapfile
         elif self.args.snapcheck is True and self.args.pre_snapfile is None:

--- a/lib/jnpr/jsnapy/jsnapy.py
+++ b/lib/jnpr/jsnapy/jsnapy.py
@@ -945,27 +945,31 @@ class SnapAdmin:
                             action))
             return res
 
-    def snap(self, data, file_name, dev=None):
+    def snap(self, data, file_name, dev=None, custom_dir=None):
         """
         Function equivalent to --snap operator, for module version
         :param data: either main config file or string containing details of main config file
         :param file_name: snap file, either complete filename or file tag
         :param dev: device object
+        :param custom_dir: custom directory path to use for lookup
         """
+        DirStore.custom_dir = custom_dir
         if isinstance(dev, Device):
             res = self.extract_dev_data(dev, data, file_name, "snap")
         else:
             res = self.extract_data(data, file_name, "snap")
         return res
 
-    def snapcheck(self, data, file_name=None, dev=None, local= False):
+    def snapcheck(self, data, file_name=None, dev=None, local= False, custom_dir=None):
         """
         Function equivalent to --snapcheck operator, for module version
         :param data: either main config file or string containing details of main config file
         :param pre_file: pre snap file, either complete filename or file tag
         :param dev: device object
+        :param custom_dir: custom directory path to use for lookup
         :return: return list of object of testop.Operator containing test details or list of dictionary of object of testop.Operator containing test details for each stored snapshot
         """
+        DirStore.custom_dir = custom_dir
         if file_name is None:
             file_name = "snap_temp"
             self.snap_del = True
@@ -975,15 +979,17 @@ class SnapAdmin:
             res = self.extract_data(data, file_name, "snapcheck")
         return res
 
-    def check(self, data, pre_file=None, post_file=None, dev=None):
+    def check(self, data, pre_file=None, post_file=None, dev=None, custom_dir=None):
         """
         Function equivalent to --check operator, for module version
         :param data: either main config file or string containing details of main config file
         :param pre_file: pre snap file, either complete filename or file tag
         :param post_file: post snap file, either complete filename or file tag
         :param dev: device object
+        :param custom_dir: custom directory path to use for lookup
         :return: return object of testop.Operator containing test details
         """
+        DirStore.custom_dir = custom_dir
         if isinstance(dev, Device):
             res = self.extract_dev_data(
                 dev,

--- a/lib/jnpr/jsnapy/jsnapy.py
+++ b/lib/jnpr/jsnapy/jsnapy.py
@@ -16,12 +16,11 @@ from copy import deepcopy
 from threading import Thread
 
 import yaml
-from jnpr.jsnapy import get_path, version
+from jnpr.jsnapy import get_path, version, get_config_location
 from jnpr.jsnapy.check import Comparator
 from jnpr.jsnapy.notify import Notification
 from jnpr.junos import Device
 from jnpr.jsnapy import version
-from jnpr.jsnapy import get_path
 from jnpr.jsnapy.operator import Operator
 from jnpr.jsnapy.snap import Parser
 from jnpr.junos.exception import ConnectAuthError
@@ -290,6 +289,10 @@ class SnapAdmin:
         read device details and connect them. Also checks sqlite key to check if user wants to
         create database for snapshots
         """
+        self.logger.debug(colorama.Fore.BLUE +
+                "jsnapy.cfg file location used : %s" %
+                get_config_location(), extra=self.log_detail)
+                
         if self.args.pre_snapfile is not None:
             output_file = self.args.pre_snapfile
         elif self.args.snapcheck is True and self.args.pre_snapfile is None:

--- a/lib/jnpr/jsnapy/setup_logging.py
+++ b/lib/jnpr/jsnapy/setup_logging.py
@@ -8,11 +8,13 @@
 import os
 import yaml
 import logging.config
+from jnpr.jsnapy import get_config_location
 
 
 def setup_logging(
         default_path='logging.yml', default_level=logging.INFO, env_key='LOG_CFG'):
-    path = os.path.join('/etc', 'jsnapy', default_path)
+    config_location = get_config_location('logging.yml')
+    path = os.path.join(config_location, default_path)
     value = os.getenv(env_key, None)
     if value:
         path = value

--- a/setup.py
+++ b/setup.py
@@ -5,17 +5,27 @@
 # All rights reserved.
 #
 
-import os
+import os,sys
+from os.path import expanduser
 from setuptools import setup, find_packages
 from setuptools.command.install import install
+import ConfigParser
 
 class OverrideInstall(install):
-
+   
     def run(self):
+        
+        for arg in sys.argv:
+            if '--install-data' in arg:
+                break
+        else:
+            self.install_data = '/etc/jsnapy'
+            
+        dir_path = self.install_data
         mode = 0o777
         install.run(self)
-        os.chmod('/etc/jsnapy', mode)
-        for root, dirs, files in os.walk('/etc/jsnapy'):
+        os.chmod(dir_path, mode)
+        for root, dirs, files in os.walk(dir_path):
             for directory in dirs:
                 os.chmod(os.path.join(root, directory), mode)
             for fname in files:
@@ -27,6 +37,35 @@ class OverrideInstall(install):
                 os.chmod(os.path.join(root, directory), mode)
             for fname in files:
                 os.chmod(os.path.join(root, fname), mode)
+        HOME = expanduser("~") #correct cross platform way to do it
+        home_folder = os.path.join(HOME,'.jsnapy')
+        if not os.path.isdir(home_folder):
+            os.mkdir(home_folder)
+            os.chmod(home_folder,mode)
+
+
+        if dir_path != '/etc/jsnapy':
+            config = ConfigParser.ConfigParser()
+            config.set('DEFAULT','config_file_path',dir_path)
+            config.set('DEFAULT','snapshot_path', os.path.join(dir_path,'snapshots'))
+            config.set('DEFAULT','test_file_path',os.path.join(dir_path,'testfiles'))
+            
+            default_config_location = "/etc/jsnapy/jsnapy.cfg"
+            if os.path.isfile(default_config_location):
+                with open(default_config_location,'w') as cfgfile:
+                    comment = ( '# This file can be overwritten\n'
+                                '# It contains default path for\n'
+                                '# config file, snapshots and testfiles\n'
+                                '# If required, overwrite the path with your path\n'
+                                '# config_file_path: path of main config file\n'
+                                '# snapshot_path : path of snapshot file\n'
+                                '# test_file_path: path of test file\n\n'
+                                )
+                    cfgfile.write(comment)
+                    config.write(cfgfile)
+            else:
+                raise Exception('jsnapy.cfg not found at /etc/jsnapy')
+        
 
 req_lines = [line.strip() for line in open(
     'requirements.txt').readlines()]
@@ -61,14 +100,12 @@ setup(name="jsnapy",
       zip_safe=False,
       install_requires=install_reqs,
       data_files=[('/etc/jsnapy', ['lib/jnpr/jsnapy/logging.yml']),
-                  ('/etc/jsnapy/samples', example_files),
+                  ('samples', example_files),
                   ('/etc/jsnapy', ['lib/jnpr/jsnapy/jsnapy.cfg']),
-                  ('/etc/jsnapy/testfiles',
-                   ['testfiles/README']),
-                  ('/etc/jsnapy/snapshots',
-                   ['snapshots/README']),
+                  ('testfiles', ['testfiles/README']),
+                  ('snapshots', ['snapshots/README']),
                   ('/var/log/jsnapy', log_files)
-                  ],
+                 ],
       cmdclass={'install': OverrideInstall},
       classifiers=[
           'Environment :: Console',

--- a/tests/unit/configs/jsnapy.cfg
+++ b/tests/unit/configs/jsnapy.cfg
@@ -1,0 +1,12 @@
+# This file can be overwritten
+# It contains default path for 
+# config file, snapshots and testfiles
+# If required, overwrite the path with your path
+#config_file_path: path of main config file
+#snapshot_path : path of snapshot file
+#test_file_path: path of test file
+
+[DEFAULT]
+config_file_path = /throgus
+snapshot_path = /bogus/snapshots
+test_file_path = /bogus/testfiles

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -1,0 +1,68 @@
+import unittest
+import os
+import yaml
+from mock import patch, MagicMock
+from nose.plugins.attrib import attr
+from jnpr.jsnapy import get_config_location, get_path, DirStore
+@attr('unit')
+class TestCheck(unittest.TestCase):
+
+    def setUp(self):
+
+        self.diff = False
+        self.chk = False
+        self.hostname = "10.216.193.114"
+        self.db = dict()
+        self.db['store_in_sqlite'] = False
+        self.db['check_from_sqlite'] = False
+        self.db['db_name'] = "jbb.db"
+        self.db['first_snap_id'] = None
+        self.db['first_snap_id'] = None
+        self.snap_del = False
+        self.action = None
+
+
+        
+    @patch('os.path.isfile')
+    def test_config_location_env(self, mock_is_file):
+        os.environ['JSNAPY_HOME'] = '/bogus/path'
+        mock_is_file.side_effect = lambda arg: arg == '/bogus/path/jsnapy.cfg'
+        loc = get_config_location()
+        self.assertEqual(loc,'/bogus/path')
+    
+    @patch('os.path.isfile')
+    def test_config_location_home(self, mock_is_file):
+        mock_is_file.side_effect = lambda arg: arg == os.path.join(os.path.expanduser('~'),'.jsnapy','jsnapy.cfg')
+        loc = get_config_location()
+        self.assertEqual(loc,os.path.join(os.path.expanduser('~'),'.jsnapy'))
+    
+    @patch('os.path.isfile')
+    def test_config_location_etc(self, mock_is_file):
+        mock_is_file.side_effect = lambda arg: arg in ['/etc/jsnapy/jsnapy.cfg']
+        loc = get_config_location()
+        self.assertEqual(loc,'/etc/jsnapy')
+    
+
+    @patch('jnpr.jsnapy.get_config_location')
+    def test_get_path_normal(self, mock_config_location):
+        DirStore.custom_dir = None
+        mock_config_location.return_value = os.path.join(os.path.dirname(__file__),'configs')
+        loc = get_path('DEFAULT','config_file_path')
+        self.assertTrue(mock_config_location.called)
+        self.assertEqual(loc,'/throgus')
+    
+    @patch('jnpr.jsnapy.get_config_location')
+    def test_get_path_custom(self, mock_config_loc):
+        DirStore.custom_dir = '~/bogus'
+        HOME = os.path.join(os.path.expanduser('~'),'bogus/')        
+        conf_loc = get_path('DEFAULT','config_file_path')
+        snap_loc = get_path('DEFAULT','snapshot_path')
+        test_loc = get_path('DEFAULT','test_file_path')
+        
+        self.assertEqual(conf_loc,HOME)
+        self.assertEqual(snap_loc,os.path.join(HOME,'snapshots'))
+        self.assertEqual(test_loc,os.path.join(HOME,'testfiles'))
+        self.assertFalse(mock_config_loc.called)
+if __name__ == "__main__":
+    suite = unittest.TestLoader().loadTestsFromTestCase(TestCheck)
+    unittest.TextTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION
Fix #171 

Introducing a new cli option '--dir' to change the lookup of configuration, testfiles and snapshots directory. 
Example:
`jsnapy --snapcheck -f config_check_no_test.yml --dir ~/Desktop/test_inst/ -v`
```bash
jsnapy.cfg file location used : /etc/jsnapy
Configuration file location used : /Users/xxxx/Desktop/test_inst/
Connecting to device xxxxx ................
Tests Included: virtual_chassis_status 
Taking snapshot of COMMAND: show virtual-chassis status 
************************** Device: xxxxx **************************
Tests Included: virtual_chassis_status 
******************** Command: show virtual-chassis status ********************
-----------------------Performing is-in Test Operation-----------------------
Test Passed!! VC members are all present
PASS | All "member-status" is in list ['Prsnt']  [ 1 matched ]
------------------------------- Final Result!! -------------------------------
Total No of tests passed: 1
Total No of tests failed: 0 
Overall Tests passed!!! 

```
Directory specified should maintain the official jsnapy hierarchy:

```
---dir_specified/
               |____ testfiles/
               |____ snapshots/
```
Custom configuration files should be placed in _dir_specified_ , test files in _dir_specified/testfiles_ directory and snapshots of the commands will then be stored in _dir_specified/snapshots_ directory

For the module version passing, _custom_dir_  option to any of the three function calls will work. Example:

```python
from jnpr.jsnapy import SnapAdmin
from pprint import pprint
from jnpr.junos import Device

js = SnapAdmin()

config_file = "config_check_no_test.yml"
js.snap(config_file, "pre", custom_dir ='~/Desktop/test_inst')
js.snap(config_file, "post", custom_dir ='~/Desktop/test_inst')

chk = js.check(config_file, "pre", "post", custom_dir ='~/Desktop/test_inst')

for check in chk:
    print "Tested on", check.device
    print "Final result: ", check.result
    print "Total passed: ", check.no_passed
    print "Total failed:", check.no_failed
    print check.test_details
    pprint(dict(check.test_details))

snapvalue = js.snapcheck(config_file, "snap", custom_dir ='~/Desktop/test_inst')
for snapcheck in snapvalue:
    print "\n -----------snapcheck----------"
    print "Tested on", snapcheck.device
    print "Final result: ", snapcheck.result
    print "Total passed: ", snapcheck.no_passed
    print "Total failed:", snapcheck.no_failed
    pprint(dict(snapcheck.test_details))
```
