### PR TITLE
Removing error for test based mail - #133

### DIFF
--- a/lib/jnpr/jsnapy/jsnapy.py
+++ b/lib/jnpr/jsnapy/jsnapy.py
@@ -571,10 +571,6 @@ class SnapAdmin:
             elif type(mail_pref) is dict: 
                 if mail_condition in mail_pref:
                     mail_file_path = mail_pref.get(mail_condition)
-                else:
-                    self.logger.error(
-                        colorama.Fore.RED +
-                        "ERROR!! File not specified for %s scenario" % mail_condition, extra=self.log_detail)
             else:
                 self.logger.error(
                     colorama.Fore.RED +


### PR DESCRIPTION
Removing error statement in scenario where key for the end result is not found in mail dictionary.

This concerns test based mail - #133 introduced via #149 