### PR TITLE
Fix for range in positive value for delta

### DIFF
--- a/lib/jnpr/jsnapy/__init__.py
+++ b/lib/jnpr/jsnapy/__init__.py
@@ -6,7 +6,6 @@
 from .version import __version__
 import ConfigParser
 import os
-import sys
 import colorama
 
 colorama.init(autoreset=True)
@@ -20,18 +19,7 @@ def get_config_location(file='jsnapy.cfg'):
     p_locations = []
     if 'JSNAPY_HOME' in os.environ:
         p_locations = [os.environ['JSNAPY_HOME']]
-
-    if hasattr(sys, 'real_prefix'):
-        p_locations.extend([os.path.join(os.path.expanduser('~'), '.jsnapy'),
-                            os.path.join(os.environ.get('VIRTUAL_ENV'),
-                            'jsnapy')])
-    elif 'win' in sys.platform:
-        p_locations.extend(
-            [os.path.join(os.path.expanduser('~'), '.jsnapy'),
-             os.path.join(os.path.expanduser('~'), 'jsnapy')])
-    else:
-        p_locations.extend([os.path.join(os.path.expanduser('~'), '.jsnapy'),
-                            '/etc/jsnapy'])
+    p_locations.extend([os.path.join(os.path.expanduser('~'), '.jsnapy'), '/etc/jsnapy'])
     for loc in p_locations:
         possible_location = os.path.join(loc, file)
         if os.path.isfile(possible_location):
@@ -40,11 +28,8 @@ def get_config_location(file='jsnapy.cfg'):
 
 
 def get_path(section, value):
-    # config = ConfigParser.ConfigParser(
-    #          {'config_file_path': '/usr/local/share/',
-    #           'snapshot_path': '/usr/local/share/snapshots',
-    #           'test_file_path': '/usr/local/share/testfiles',
-    #           'log_file_path': '/var/log/jsnapy'})
+    # config = ConfigParser.ConfigParser({'config_file_path': '/usr/local/share/', 'snapshot_path': '/usr/local/share/snapshots',
+    #                                     'test_file_path': '/usr/local/share/testfiles', 'log_file_path': '/var/log/jsnapy'})
     custom_dir = DirStore.custom_dir
     if custom_dir:
         paths = {'config_file_path': '',

--- a/lib/jnpr/jsnapy/__init__.py
+++ b/lib/jnpr/jsnapy/__init__.py
@@ -5,7 +5,7 @@
 
 from .version import __version__
 import ConfigParser
-import os
+import os, sys
 import colorama
 colorama.init(autoreset=True)
 
@@ -15,14 +15,22 @@ class DirStore:
 def get_config_location(file='jsnapy.cfg'):
     p_locations = []
     if 'JSNAPY_HOME' in os.environ:
-        p_locations = [os.environ['JSNAPY_HOME']]   
-    p_locations.extend([os.path.join(os.path.expanduser('~'),'.jsnapy'),'/etc/jsnapy'])
+        p_locations = [os.environ['JSNAPY_HOME']]
+
+    if hasattr(sys, 'real_prefix'):
+        p_locations.extend([os.path.join(os.path.expanduser('~'), '.jsnapy'),
+                            os.path.join(os.environ.get('VIRTUAL_ENV'), 'jsnapy')])
+    elif 'win' in sys.platform:
+        p_locations.extend(
+            [os.path.join(os.path.expanduser('~'), '.jsnapy'), os.path.join(os.path.expanduser('~'), 'jsnapy')])
+    else:
+        p_locations.extend([os.path.join(os.path.expanduser('~'), '.jsnapy'), '/etc/jsnapy'])
     for loc in p_locations:
-        possible_location =  os.path.join(loc,file)
+        possible_location = os.path.join(loc, file)
         if os.path.isfile(possible_location):
             return loc
     return None
-    
+
 
 def get_path(section, value):
     # config = ConfigParser.ConfigParser({'config_file_path': '/usr/local/share/', 'snapshot_path': '/usr/local/share/snapshots',

--- a/lib/jnpr/jsnapy/__init__.py
+++ b/lib/jnpr/jsnapy/__init__.py
@@ -5,13 +5,17 @@
 
 from .version import __version__
 import ConfigParser
-import os, sys
+import os
+import sys
 import colorama
+
 colorama.init(autoreset=True)
+
 
 class DirStore:
     custom_dir = None
-        
+
+
 def get_config_location(file='jsnapy.cfg'):
     p_locations = []
     if 'JSNAPY_HOME' in os.environ:
@@ -19,12 +23,15 @@ def get_config_location(file='jsnapy.cfg'):
 
     if hasattr(sys, 'real_prefix'):
         p_locations.extend([os.path.join(os.path.expanduser('~'), '.jsnapy'),
-                            os.path.join(os.environ.get('VIRTUAL_ENV'), 'jsnapy')])
+                            os.path.join(os.environ.get('VIRTUAL_ENV'),
+                            'jsnapy')])
     elif 'win' in sys.platform:
         p_locations.extend(
-            [os.path.join(os.path.expanduser('~'), '.jsnapy'), os.path.join(os.path.expanduser('~'), 'jsnapy')])
+            [os.path.join(os.path.expanduser('~'), '.jsnapy'),
+             os.path.join(os.path.expanduser('~'), 'jsnapy')])
     else:
-        p_locations.extend([os.path.join(os.path.expanduser('~'), '.jsnapy'), '/etc/jsnapy'])
+        p_locations.extend([os.path.join(os.path.expanduser('~'), '.jsnapy'),
+                            '/etc/jsnapy'])
     for loc in p_locations:
         possible_location = os.path.join(loc, file)
         if os.path.isfile(possible_location):
@@ -33,27 +40,31 @@ def get_config_location(file='jsnapy.cfg'):
 
 
 def get_path(section, value):
-    # config = ConfigParser.ConfigParser({'config_file_path': '/usr/local/share/', 'snapshot_path': '/usr/local/share/snapshots',
-    #                                     'test_file_path': '/usr/local/share/testfiles', 'log_file_path': '/var/log/jsnapy'})
+    # config = ConfigParser.ConfigParser(
+    #          {'config_file_path': '/usr/local/share/',
+    #           'snapshot_path': '/usr/local/share/snapshots',
+    #           'test_file_path': '/usr/local/share/testfiles',
+    #           'log_file_path': '/var/log/jsnapy'})
     custom_dir = DirStore.custom_dir
     if custom_dir:
         paths = {'config_file_path': '',
-                'snapshot_path': 'snapshots',
-                'test_file_path': 'testfiles'}
+                 'snapshot_path': 'snapshots',
+                 'test_file_path': 'testfiles'}
         if custom_dir.startswith('~/'):
-            custom_dir = os.path.join(os.path.expanduser('~'),custom_dir[2:])
+            custom_dir = os.path.join(os.path.expanduser('~'), custom_dir[2:])
         complete_paths = {}
         for p in paths:
-            complete_paths[p]= os.path.join(custom_dir,paths[p])
+            complete_paths[p] = os.path.join(custom_dir, paths[p])
         path = complete_paths.get(value)
-    else:    
+    else:
         config = ConfigParser.ConfigParser()
         config_location = get_config_location()
         if config_location is None:
             raise Exception('Config file not found')
-        config_location = os.path.join(config_location,'jsnapy.cfg')
+        config_location = os.path.join(config_location, 'jsnapy.cfg')
         config.read(config_location)
         path = config.get(section, value)
     return path
+
 
 from jnpr.jsnapy.jsnapy import SnapAdmin

--- a/lib/jnpr/jsnapy/operator.py
+++ b/lib/jnpr/jsnapy/operator.py
@@ -2761,7 +2761,7 @@ class Operator:
                                 elif re.search('\+', del_val):
                                     dvalue = float(delta_val.strip('%'))
                                     mvalue = val1 + dvalue
-                                    if (val2 >= mvalue or val2 <= val1):
+                                    if (val2 > mvalue or val2 < val1):
                                         res = False
                                         count_fail = count_fail + 1
                                         self._print_message(

--- a/lib/jnpr/jsnapy/operator.py
+++ b/lib/jnpr/jsnapy/operator.py
@@ -2642,7 +2642,7 @@ class Operator:
                                             deepcopy(node_value_passed))
 
                                 # for positive percent change
-                                elif re.search('%', del_val) and (re.search('/+', del_val)):
+                                elif re.search('%', del_val) and (re.search('\+', del_val)):
                                     dvalue = float(delta_val.strip('%'))
                                     mvalue = val1 + ((val1 * dvalue) / 100)
                                     if (val2 < val1 or val2 > mvalue):

--- a/lib/jnpr/jsnapy/setup_logging.py
+++ b/lib/jnpr/jsnapy/setup_logging.py
@@ -5,7 +5,7 @@
 # All rights reserved.
 #
 
-import os
+import os, sys
 import yaml
 import logging.config
 from jnpr.jsnapy import get_config_location
@@ -21,6 +21,19 @@ def setup_logging(
     if os.path.exists(path):
         with open(path, 'rt') as f:
             config = yaml.load(f.read())
+            for handler, value in config['handlers'].iteritems():
+                if handler == 'console':
+                    pass
+                else:
+                    if hasattr(sys,'real_prefix'):
+                        value['filename'] = (os.path.join(os.environ.get('VIRTUAL_ENV'),'logs/jsnapy/jsnapy.log'))
+                    elif 'win' in sys.platform:
+                        value['filename'] = (os.path.join(os.path.expanduser('~'),
+                                       'logs\jsnapy\jsnapy.log'))
+
+                with open(path, "w") as f:
+                    yaml.dump(config, f, default_flow_style=False)
         logging.config.dictConfig(config)
     else:
         logging.basicConfig(level=default_level)
+

--- a/lib/jnpr/jsnapy/setup_logging.py
+++ b/lib/jnpr/jsnapy/setup_logging.py
@@ -5,7 +5,7 @@
 # All rights reserved.
 #
 
-import os, sys
+import os
 import yaml
 import logging.config
 from jnpr.jsnapy import get_config_location
@@ -21,19 +21,6 @@ def setup_logging(
     if os.path.exists(path):
         with open(path, 'rt') as f:
             config = yaml.load(f.read())
-            for handler, value in config['handlers'].iteritems():
-                if handler == 'console':
-                    pass
-                else:
-                    if hasattr(sys,'real_prefix'):
-                        value['filename'] = (os.path.join(os.environ.get('VIRTUAL_ENV'),'logs/jsnapy/jsnapy.log'))
-                    elif 'win' in sys.platform:
-                        value['filename'] = (os.path.join(os.path.expanduser('~'),
-                                       'logs\jsnapy\jsnapy.log'))
-
-                with open(path, "w") as f:
-                    yaml.dump(config, f, default_flow_style=False)
         logging.config.dictConfig(config)
     else:
         logging.basicConfig(level=default_level)
-

--- a/setup.py
+++ b/setup.py
@@ -19,33 +19,24 @@ class OverrideInstall(install):
             if '--install-data' in arg:
                 break
         else:
-            if hasattr(sys, 'real_prefix'):
-                self.install_data = os.path.join(os.environ.get('VIRTUAL_ENV'),'jsnapy')
-            elif 'win' in sys.platform:
-                self.install_data = os.path.join(os.path.expanduser('~'),'jsnapy')
-            else:
-                self.install_data = '/etc/jsnapy'
+            self.install_data = '/etc/jsnapy'
 
         dir_path = self.install_data
         mode = 0o777
         install.run(self)
+        os.chmod(dir_path, mode)
+        for root, dirs, files in os.walk(dir_path):
+            for directory in dirs:
+                os.chmod(os.path.join(root, directory), mode)
+            for fname in files:
+                os.chmod(os.path.join(root, fname), mode)
 
-        if 'win' not in sys.platform and not hasattr(sys, 'real_prefix'):
-            os.chmod(dir_path, mode)
-            for root, dirs, files in os.walk(dir_path):
-                for directory in dirs:
-                    os.chmod(os.path.join(root, directory), mode)
-                for fname in files:
-                    os.chmod(os.path.join(root, fname), mode)
-
-            os.chmod('/var/log/jsnapy', mode)
-            for root, dirs, files in os.walk('/var/log/jsnapy'):
-                for directory in dirs:
-                    os.chmod(os.path.join(root, directory), mode)
-                for fname in files:
-                    os.chmod(os.path.join(root, fname), mode)
-
-	
+        os.chmod('/var/log/jsnapy', mode)
+        for root, dirs, files in os.walk('/var/log/jsnapy'):
+            for directory in dirs:
+                os.chmod(os.path.join(root, directory), mode)
+            for fname in files:
+                os.chmod(os.path.join(root, fname), mode)
         HOME = expanduser("~")  # correct cross platform way to do it
         home_folder = os.path.join(HOME, '.jsnapy')
         if not os.path.isdir(home_folder):
@@ -58,29 +49,21 @@ class OverrideInstall(install):
             config.set('DEFAULT', 'snapshot_path', os.path.join(dir_path, 'snapshots'))
             config.set('DEFAULT', 'test_file_path', os.path.join(dir_path, 'testfiles'))
 
-            if hasattr(sys, 'real_prefix'):
-                default_config_location = [os.path.join(HOME,'jsnapy\jsnapy.cfg'), "/etc/jsnapy/jsnapy.cfg",
-				           os.path.join(os.environ.get('VIRTUAL_ENV'),'jsnapy/jsnapy.cfg')]
+            default_config_location = "/etc/jsnapy/jsnapy.cfg"
+            if os.path.isfile(default_config_location):
+                with open(default_config_location, 'w') as cfgfile:
+                    comment = ('# This file can be overwritten\n'
+                               '# It contains default path for\n'
+                               '# config file, snapshots and testfiles\n'
+                               '# If required, overwrite the path with your path\n'
+                               '# config_file_path: path of main config file\n'
+                               '# snapshot_path : path of snapshot file\n'
+                               '# test_file_path: path of test file\n\n'
+                               )
+                    cfgfile.write(comment)
+                    config.write(cfgfile)
             else:
-                default_config_location = [os.path.join(HOME, 'jsnapy\jsnapy.cfg'), "/etc/jsnapy/jsnapy.cfg"]
-
-            flag = False
-            for possible_location in default_config_location:
-                if os.path.isfile(possible_location):
-                    with open(possible_location, 'w') as cfgfile:
-                        comment = ('# This file can be overwritten\n'
-                                   '# It contains default path for\n'
-                                   '# config file, snapshots and testfiles\n'
-                                   '# If required, overwrite the path with your path\n'
-                                   '# config_file_path: path of main config file\n'
-                                   '# snapshot_path : path of snapshot file\n'
-                                   '# test_file_path: path of test file\n\n'
-                                   )
-                        cfgfile.write(comment)
-                        config.write(cfgfile)
-                        flag = True
-            if flag == False:
-                raise Exception('jsnapy.cfg not found at any possible location')
+                raise Exception('jsnapy.cfg not found at /etc/jsnapy')
 
 
 req_lines = [line.strip() for line in open(
@@ -93,39 +76,6 @@ example_files = [
 log_files = [os.path.join('logs', j)
              for j in os.listdir('logs')]
 exec (open('lib/jnpr/jsnapy/version.py').read())
-
-
-os_data_file = []
-
-if hasattr(sys,'real_prefix'):
-    HOME = os.environ.get('VIRTUAL_ENV')
-    os_data_file = [(os.path.join(HOME,'jsnapy'),['lib/jnpr/jsnapy/logging.yml']),
-                    (os.path.join(HOME,'logs/jsnapy'),log_files),
-                    ('samples',example_files),
-                    (os.path.join(HOME,'jsnapy'), ['lib/jnpr/jsnapy/jsnapy.cfg']),
-                    ('testfiles', ['testfiles/README']),
-                    ('snapshots', ['snapshots/README'])
-                    ]
-
-
-elif 'win' in sys.platform:
-    HOME = expanduser("~")
-    os_data_file = [(os.path.join(HOME,'jsnapy'),['lib/jnpr/jsnapy/logging.yml']),
-                    (os.path.join(HOME,'logs\jsnapy'),log_files),
-		    ('samples',example_files),
-                    (os.path.join(HOME,'jsnapy'), ['lib/jnpr/jsnapy/jsnapy.cfg']),
-                    ('testfiles', ['testfiles/README']),
-                    ('snapshots', ['snapshots/README'])
-                    ]
-
-else:
-    os_data_file = [('/etc/jsnapy', ['lib/jnpr/jsnapy/logging.yml']),
-                    ('samples', example_files),
-                    ('/etc/jsnapy', ['lib/jnpr/jsnapy/jsnapy.cfg']),
-                    ('testfiles', ['testfiles/README']),
-                    ('snapshots', ['snapshots/README']),
-                    ('/var/log/jsnapy', log_files)
-                   ]
 
 setup(name="jsnapy",
       version=__version__,
@@ -148,7 +98,13 @@ setup(name="jsnapy",
       scripts=['tools/jsnap2py'],
       zip_safe=False,
       install_requires=install_reqs,
-      data_files=os_data_file,
+      data_files=[('/etc/jsnapy', ['lib/jnpr/jsnapy/logging.yml']),
+                  ('samples', example_files),
+                  ('/etc/jsnapy', ['lib/jnpr/jsnapy/jsnapy.cfg']),
+                  ('testfiles', ['testfiles/README']),
+                  ('snapshots', ['snapshots/README']),
+                  ('/var/log/jsnapy', log_files)
+                  ],
       cmdclass={'install': OverrideInstall},
       classifiers=[
           'Environment :: Console',

--- a/setup.py
+++ b/setup.py
@@ -5,67 +5,83 @@
 # All rights reserved.
 #
 
-import os,sys
+import os, sys
 from os.path import expanduser
 from setuptools import setup, find_packages
 from setuptools.command.install import install
 import ConfigParser
 
+
 class OverrideInstall(install):
-   
     def run(self):
-        
+
         for arg in sys.argv:
             if '--install-data' in arg:
                 break
         else:
-            self.install_data = '/etc/jsnapy'
-            
+            if hasattr(sys, 'real_prefix'):
+                self.install_data = os.path.join(os.environ.get('VIRTUAL_ENV'),'jsnapy')
+            elif 'win' in sys.platform:
+                self.install_data = os.path.join(os.path.expanduser('~'),'jsnapy')
+            else:
+                self.install_data = '/etc/jsnapy'
+
         dir_path = self.install_data
         mode = 0o777
         install.run(self)
-        os.chmod(dir_path, mode)
-        for root, dirs, files in os.walk(dir_path):
-            for directory in dirs:
-                os.chmod(os.path.join(root, directory), mode)
-            for fname in files:
-                os.chmod(os.path.join(root, fname), mode)
 
-        os.chmod('/var/log/jsnapy', mode)
-        for root, dirs, files in os.walk('/var/log/jsnapy'):
-            for directory in dirs:
-                os.chmod(os.path.join(root, directory), mode)
-            for fname in files:
-                os.chmod(os.path.join(root, fname), mode)
-        HOME = expanduser("~") #correct cross platform way to do it
-        home_folder = os.path.join(HOME,'.jsnapy')
+        if 'win' not in sys.platform and not hasattr(sys, 'real_prefix'):
+            os.chmod(dir_path, mode)
+            for root, dirs, files in os.walk(dir_path):
+                for directory in dirs:
+                    os.chmod(os.path.join(root, directory), mode)
+                for fname in files:
+                    os.chmod(os.path.join(root, fname), mode)
+
+            os.chmod('/var/log/jsnapy', mode)
+            for root, dirs, files in os.walk('/var/log/jsnapy'):
+                for directory in dirs:
+                    os.chmod(os.path.join(root, directory), mode)
+                for fname in files:
+                    os.chmod(os.path.join(root, fname), mode)
+
+	
+        HOME = expanduser("~")  # correct cross platform way to do it
+        home_folder = os.path.join(HOME, '.jsnapy')
         if not os.path.isdir(home_folder):
             os.mkdir(home_folder)
-            os.chmod(home_folder,mode)
-
+            os.chmod(home_folder, mode)
 
         if dir_path != '/etc/jsnapy':
             config = ConfigParser.ConfigParser()
-            config.set('DEFAULT','config_file_path',dir_path)
-            config.set('DEFAULT','snapshot_path', os.path.join(dir_path,'snapshots'))
-            config.set('DEFAULT','test_file_path',os.path.join(dir_path,'testfiles'))
-            
-            default_config_location = "/etc/jsnapy/jsnapy.cfg"
-            if os.path.isfile(default_config_location):
-                with open(default_config_location,'w') as cfgfile:
-                    comment = ( '# This file can be overwritten\n'
-                                '# It contains default path for\n'
-                                '# config file, snapshots and testfiles\n'
-                                '# If required, overwrite the path with your path\n'
-                                '# config_file_path: path of main config file\n'
-                                '# snapshot_path : path of snapshot file\n'
-                                '# test_file_path: path of test file\n\n'
-                                )
-                    cfgfile.write(comment)
-                    config.write(cfgfile)
+            config.set('DEFAULT', 'config_file_path', dir_path)
+            config.set('DEFAULT', 'snapshot_path', os.path.join(dir_path, 'snapshots'))
+            config.set('DEFAULT', 'test_file_path', os.path.join(dir_path, 'testfiles'))
+
+            if hasattr(sys, 'real_prefix'):
+                default_config_location = [os.path.join(HOME,'jsnapy\jsnapy.cfg'), "/etc/jsnapy/jsnapy.cfg",
+				           os.path.join(os.environ.get('VIRTUAL_ENV'),'jsnapy/jsnapy.cfg')]
             else:
-                raise Exception('jsnapy.cfg not found at /etc/jsnapy')
-        
+                default_config_location = [os.path.join(HOME, 'jsnapy\jsnapy.cfg'), "/etc/jsnapy/jsnapy.cfg"]
+
+            flag = False
+            for possible_location in default_config_location:
+                if os.path.isfile(possible_location):
+                    with open(possible_location, 'w') as cfgfile:
+                        comment = ('# This file can be overwritten\n'
+                                   '# It contains default path for\n'
+                                   '# config file, snapshots and testfiles\n'
+                                   '# If required, overwrite the path with your path\n'
+                                   '# config_file_path: path of main config file\n'
+                                   '# snapshot_path : path of snapshot file\n'
+                                   '# test_file_path: path of test file\n\n'
+                                   )
+                        cfgfile.write(comment)
+                        config.write(cfgfile)
+                        flag = True
+            if flag == False:
+                raise Exception('jsnapy.cfg not found at any possible location')
+
 
 req_lines = [line.strip() for line in open(
     'requirements.txt').readlines()]
@@ -76,7 +92,40 @@ example_files = [
         i) for i in os.listdir('samples')]
 log_files = [os.path.join('logs', j)
              for j in os.listdir('logs')]
-exec(open('lib/jnpr/jsnapy/version.py').read())
+exec (open('lib/jnpr/jsnapy/version.py').read())
+
+
+os_data_file = []
+
+if hasattr(sys,'real_prefix'):
+    HOME = os.environ.get('VIRTUAL_ENV')
+    os_data_file = [(os.path.join(HOME,'jsnapy'),['lib/jnpr/jsnapy/logging.yml']),
+                    (os.path.join(HOME,'logs/jsnapy'),log_files),
+                    ('samples',example_files),
+                    (os.path.join(HOME,'jsnapy'), ['lib/jnpr/jsnapy/jsnapy.cfg']),
+                    ('testfiles', ['testfiles/README']),
+                    ('snapshots', ['snapshots/README'])
+                    ]
+
+
+elif 'win' in sys.platform:
+    HOME = expanduser("~")
+    os_data_file = [(os.path.join(HOME,'jsnapy'),['lib/jnpr/jsnapy/logging.yml']),
+                    (os.path.join(HOME,'logs\jsnapy'),log_files),
+		    ('samples',example_files),
+                    (os.path.join(HOME,'jsnapy'), ['lib/jnpr/jsnapy/jsnapy.cfg']),
+                    ('testfiles', ['testfiles/README']),
+                    ('snapshots', ['snapshots/README'])
+                    ]
+
+else:
+    os_data_file = [('/etc/jsnapy', ['lib/jnpr/jsnapy/logging.yml']),
+                    ('samples', example_files),
+                    ('/etc/jsnapy', ['lib/jnpr/jsnapy/jsnapy.cfg']),
+                    ('testfiles', ['testfiles/README']),
+                    ('snapshots', ['snapshots/README']),
+                    ('/var/log/jsnapy', log_files)
+                   ]
 
 setup(name="jsnapy",
       version=__version__,
@@ -89,7 +138,7 @@ setup(name="jsnapy",
       package_dir={'': 'lib'},
       packages=find_packages('lib'),
       package_data={
-           'jnpr.jsnapy': ['jsnapy.cfg', 'logging.yml', 'content.html'],
+          'jnpr.jsnapy': ['jsnapy.cfg', 'logging.yml', 'content.html'],
       },
       entry_points={
           'console_scripts': [
@@ -99,13 +148,7 @@ setup(name="jsnapy",
       scripts=['tools/jsnap2py'],
       zip_safe=False,
       install_requires=install_reqs,
-      data_files=[('/etc/jsnapy', ['lib/jnpr/jsnapy/logging.yml']),
-                  ('samples', example_files),
-                  ('/etc/jsnapy', ['lib/jnpr/jsnapy/jsnapy.cfg']),
-                  ('testfiles', ['testfiles/README']),
-                  ('snapshots', ['snapshots/README']),
-                  ('/var/log/jsnapy', log_files)
-                 ],
+      data_files=os_data_file,
       cmdclass={'install': OverrideInstall},
       classifiers=[
           'Environment :: Console',


### PR DESCRIPTION
The following is the test case
```
test_command_version:
  - command: show route
  - iterate:
      xpath: //route-information/route-table
      id: [table-name]
      tests:
        - delta: destination-count, +5
          err: "{{pre['table-name']}} has pre value {{pre['destination-count']}} and post value is {{post['destination-count']}} and not within delta."
          info: "{{pre['table-name']}} has pre value {{pre['destination-count']}} and post value is {{post['destination-count']}} and is within delta."
```

Now if the value in pre and post snapshots, output is 
```
route-tbl1 has pre value 1.0 and post value is 1.0 and not within delta 
route-tbl2 has pre value 33.0 and post value is 33.0 and not within delta 
route-tbl3 has pre value 3.0 and post value is 3.0 and not within delta
FAIL | All "destination-count" is not with in delta difference of +5 [ 0 matched / 3 failed ]
```
and the desired output is that it should pass, as it is happening in other delta operator conditions where the values do not change in pre and post snapshots and output it as pass.