### PR TITLE
Testop correction

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ install:
 
 before_script:
   - export PYTHONPATH=$VIRTUAL_ENV/lib/python$TRAVIS_PYTHON_VERSION/site-packages
-  - cd tests/unit
 
 script: 
   nosetests -v --with-coverage --cover-package=jnpr.jsnapy --cover-inclusive -a unit

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
 
 before_script:
   - export PYTHONPATH=$VIRTUAL_ENV/lib/python$TRAVIS_PYTHON_VERSION/site-packages
-
+  - cd tests/unit
 script: 
   nosetests -v --with-coverage --cover-package=jnpr.jsnapy --cover-inclusive -a unit
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ install:
 
 before_script:
   - export PYTHONPATH=$VIRTUAL_ENV/lib/python$TRAVIS_PYTHON_VERSION/site-packages
+  - cd tests/unit
 
 script: 
   nosetests -v --with-coverage --cover-package=jnpr.jsnapy --cover-inclusive -a unit

--- a/lib/jnpr/jsnapy/check.py
+++ b/lib/jnpr/jsnapy/check.py
@@ -128,6 +128,11 @@ class Comparator:
             return
         return xml_value
 
+    def _get_testop(self, elem_list):
+        exclusion_list = ['err', 'info', 'ignore-null']
+        testop = [key.lower() for key in elem_list if key.lower() not in exclusion_list]
+        testop = testop[0] if testop else "Define test operator"
+        return testop
 
     def expression_evaluator(self, elem_test, op, x_path, id_list, iter, teston,
                                 check, db, snap1, snap2=None, action=None, top_ignore_null=None):
@@ -150,9 +155,8 @@ class Comparator:
         """
         # analyze individual test case and extract element list, info and
         # err message ####
-        exclusion_list = ['err', 'info', 'ignore-null']
-        testop = [key.lower() for key in elem_test if key.lower() not in exclusion_list]
-        testop = testop[0] if testop else "Define test operator"
+
+        testop = self._get_testop(elem_test)
 
         ele = elem_test.get(testop)
         if ele is not None:
@@ -261,9 +265,8 @@ class Comparator:
                 last_test_instance = kwargs['op'].test_details[kwargs['teston']][-1]
                 res = last_test_instance['result']
 
-                exclusion_list = ['err', 'info', 'ignore-null']
-                testop = [key.lower() for key in elem if key.lower() not in exclusion_list]
-                testop = testop[0] if testop else "Define test operator"
+                testop = self._get_testop(elem)
+                
                 #for skipping cases
                 if res is None or (last_test_instance['count']['pass'] == 0 and
                                    last_test_instance['count']['fail'] == 0 and

--- a/lib/jnpr/jsnapy/check.py
+++ b/lib/jnpr/jsnapy/check.py
@@ -150,11 +150,9 @@ class Comparator:
         """
         # analyze individual test case and extract element list, info and
         # err message ####
-        values = ['err', 'info']
-        testvalues = elem_test.keys()
-        testop1 = [
-            tvalue for tvalue in testvalues if tvalue not in values]
-        testop = testop1[0] if testop1 else "Define test operator"
+        exclusion_list = ['err', 'info', 'ignore-null']
+        testop = [key.lower() for key in elem_test if key.lower() not in exclusion_list]
+        testop = testop[0] if testop else "Define test operator"
 
         ele = elem_test.get(testop)
         if ele is not None:

--- a/lib/jnpr/jsnapy/check.py
+++ b/lib/jnpr/jsnapy/check.py
@@ -570,7 +570,7 @@ class Comparator:
                         (val),
                         extra=self.log_detail)
                     try:
-                        if 'command' in (tests[val][0].keys())[0]:
+                        if 'command' in list(tests[val][0].keys()):
                             command = tests[val][0].get('command').split('|')[0].strip()
                             reply_format = tests[val][0].get('format', 'xml')
                             message = self._print_testmssg("Command: "+command, "*")

--- a/lib/jnpr/jsnapy/check.py
+++ b/lib/jnpr/jsnapy/check.py
@@ -261,11 +261,9 @@ class Comparator:
                 last_test_instance = kwargs['op'].test_details[kwargs['teston']][-1]
                 res = last_test_instance['result']
 
-                values = ['err', 'info']
-                testvalues = elem.keys()
-                testop1 = [
-                    tvalue for tvalue in testvalues if tvalue not in values]
-                testop = testop1[0] if testop1 else "Define test operator"
+                exclusion_list = ['err', 'info', 'ignore-null']
+                testop = [key.lower() for key in elem if key.lower() not in exclusion_list]
+                testop = testop[0] if testop else "Define test operator"
                 #for skipping cases
                 if res is None or (last_test_instance['count']['pass'] == 0 and
                                    last_test_instance['count']['fail'] == 0 and
@@ -569,7 +567,7 @@ class Comparator:
                         (val),
                         extra=self.log_detail)
                     try:
-                        if tests[val][0].keys()[0] == 'command':
+                        if 'command' in (tests[val][0].keys())[0]:
                             command = tests[val][0].get('command').split('|')[0].strip()
                             reply_format = tests[val][0].get('format', 'xml')
                             message = self._print_testmssg("Command: "+command, "*")


### PR DESCRIPTION
When https://github.com/Juniper/jsnapy/compare/master...sidhujasminder:testop_correction?expand=1#diff-6f4f0e74cea88c21aa9dbdcb8cb6c625L153 is executed, the next line tries to form a list out of the keys(), which may be in any order and in later version of python might cause issues. So, adding this new change would take care of the order problem.