### PR TITLE
Windows virtualenv support

### DIFF
--- a/lib/jnpr/jsnapy/__init__.py
+++ b/lib/jnpr/jsnapy/__init__.py
@@ -23,8 +23,7 @@ def get_config_location(file='jsnapy.cfg'):
 
     if hasattr(sys, 'real_prefix'):
         p_locations.extend([os.path.join(os.path.expanduser("~"),'.jsnapy'),
-                            os.path.join(sys.prefix,'etc'
-                                         'jsnapy')])
+                            os.path.join(sys.prefix,'etc/jsnapy')])
     elif 'win' in sys.platform:
         p_locations.extend(
             [os.path.join(os.path.expanduser("~"),'.jsnapy'),

--- a/lib/jnpr/jsnapy/__init__.py
+++ b/lib/jnpr/jsnapy/__init__.py
@@ -22,13 +22,16 @@ def get_config_location(file='jsnapy.cfg'):
         p_locations = [os.environ['JSNAPY_HOME']]
 
     if hasattr(sys, 'real_prefix'):
-        p_locations.extend([os.path.join(os.path.expanduser('~'),
-                                         '.jsnapy', 'jsnapy')])
+        p_locations.extend([os.path.join(os.path.expanduser("~"),'.jsnapy'),
+                            os.path.join(sys.prefix,'etc'
+                                         'jsnapy')])
     elif 'win' in sys.platform:
         p_locations.extend(
-            [os.path.join(os.path.expanduser('~'), 'jsnapy')])
+            [os.path.join(os.path.expanduser("~"),'.jsnapy'),
+             os.path.join(os.path.expanduser('~'), 'jsnapy')])
     else:
-        p_locations.extend(['/etc/jsnapy'])
+        p_locations.extend([os.path.join(os.path.expanduser("~"),'.jsnapy'),
+                            '/etc/jsnapy'])
     
     for loc in p_locations:
         possible_location = os.path.join(loc, file)

--- a/lib/jnpr/jsnapy/__init__.py
+++ b/lib/jnpr/jsnapy/__init__.py
@@ -22,16 +22,16 @@ def get_config_location(file='jsnapy.cfg'):
         p_locations = [os.environ['JSNAPY_HOME']]
 
     if hasattr(sys, 'real_prefix'):
-        p_locations.extend([os.path.join(os.path.expanduser("~"),'.jsnapy'),
-                            os.path.join(sys.prefix,'etc/jsnapy')])
+        p_locations.extend([os.path.join(os.path.expanduser("~"), '.jsnapy'),
+                            os.path.join(sys.prefix, 'etc/jsnapy')])
     elif 'win' in sys.platform:
         p_locations.extend(
-            [os.path.join(os.path.expanduser("~"),'.jsnapy'),
+            [os.path.join(os.path.expanduser("~"), '.jsnapy'),
              os.path.join(os.path.expanduser('~'), 'jsnapy')])
     else:
-        p_locations.extend([os.path.join(os.path.expanduser("~"),'.jsnapy'),
+        p_locations.extend([os.path.join(os.path.expanduser("~"), '.jsnapy'),
                             '/etc/jsnapy'])
-    
+
     for loc in p_locations:
         possible_location = os.path.join(loc, file)
         if os.path.isfile(possible_location):

--- a/lib/jnpr/jsnapy/setup_logging.py
+++ b/lib/jnpr/jsnapy/setup_logging.py
@@ -13,7 +13,8 @@ from jnpr.jsnapy import get_config_location
 
 
 def setup_logging(
-        default_path='logging.yml', default_level=logging.INFO, env_key='LOG_CFG'):
+        default_path='logging.yml', default_level=logging.INFO,
+        env_key='LOG_CFG'):
     config_location = get_config_location('logging.yml')
     path = os.path.join(config_location, default_path)
     value = os.getenv(env_key, None)

--- a/lib/jnpr/jsnapy/setup_logging.py
+++ b/lib/jnpr/jsnapy/setup_logging.py
@@ -28,13 +28,12 @@ def setup_logging(
                 else:
                     if hasattr(sys, 'real_prefix'):
                         value['filename'] = (os.path.join
-                                             (sys.prefix, 'etc'
-                                              'jsnapy',
-                                              'logs', 'jsnapy','jsnapy.log'))
+                                             (sys.prefix,
+                                              'var/logs/jsnapy/jsnapy.log'))
                     elif 'win' in sys.platform:
                         value['filename'] = (os.path.join
                                              (os.path.expanduser('~'),
-                                              'logs', 'jsnapy', 'jsnapy.log'))
+                                              'logs\jsnapy\jsnapy.log'))
 
                 with open(path, "w") as f:
                     yaml.dump(config, f, default_flow_style=False)

--- a/lib/jnpr/jsnapy/setup_logging.py
+++ b/lib/jnpr/jsnapy/setup_logging.py
@@ -28,13 +28,13 @@ def setup_logging(
                 else:
                     if hasattr(sys, 'real_prefix'):
                         value['filename'] = (os.path.join
-                                             (os.path.expanduser("~"),
-                                              '.jsnapy',
-                                              'logs/jsnapy/jsnapy.log'))
+                                             (sys.prefix, 'etc'
+                                              'jsnapy',
+                                              'logs', 'jsnapy','jsnapy.log'))
                     elif 'win' in sys.platform:
                         value['filename'] = (os.path.join
                                              (os.path.expanduser('~'),
-                                              'logs\jsnapy\jsnapy.log'))
+                                              'logs', 'jsnapy', 'jsnapy.log'))
 
                 with open(path, "w") as f:
                     yaml.dump(config, f, default_flow_style=False)

--- a/setup.py
+++ b/setup.py
@@ -89,9 +89,8 @@ class OverrideInstall(install):
                                )
                     cfgfile.write(comment)
                     config.write(cfgfile)
-                    flag = True
             else:
-                raise Exception('jsnapy.cfg not found at %s',default_config_location)
+                raise Exception('jsnapy.cfg not found at '+ default_config_location)
         
 
 req_lines = [line.strip() for line in open(

--- a/setup.py
+++ b/setup.py
@@ -66,13 +66,14 @@ class OverrideInstall(install):
                        os.path.join(dir_path,'testfiles'))
 
             if hasattr(sys, 'real_prefix'):
-                default_config_location = [os.path.join
+                default_config_location = [os.path.join(sys.prefix,
+                                                        'etc',
+                                                        'jsnapy', 'jsnapy.cfg'),
+                                            os.path.join
                                            (expanduser("~"),
                                             'jsnapy', 'jsnapy.cfg'),
-                                           "/etc/jsnapy/jsnapy.cfg",
-                                           os.path.join(expanduser("~"),
-                                                        '.jsnapy',
-                                                        'jsnapy', 'jsnapy.cfg')]
+                                           "/etc/jsnapy/jsnapy.cfg"
+                                          ]
             else:
                 default_config_location = [os.path.join(expanduser("~"),
                                                         'jsnapy', 'jsnapy.cfg'),
@@ -115,7 +116,7 @@ if hasattr(sys, 'real_prefix'):
     home = os.path.join(sys.prefix,'etc')
     os_data_file = [(os.path.join(home, 'jsnapy'),
                     ['lib/jnpr/jsnapy/logging.yml']),
-                    (os.path.join(home, 'var', 'logs', 'jsnapy'),
+                    (os.path.join(sys.prefix, 'var', 'logs', 'jsnapy'),
                      log_files),
                     ('samples', example_files),
                     (os.path.join(home, 'jsnapy'),

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-
 #!/usr/bin/python
 
 # Copyright (c) 1999-2016, Juniper Networks Inc.
@@ -13,14 +12,19 @@ from setuptools import setup, find_packages
 from setuptools.command.install import install
 import ConfigParser
 
+
 class OverrideInstall(install):
-   
+
     def run(self):
-        
+
         for arg in sys.argv:
             if '--install-data' in arg:
                 break
         else:
+            #--------------------------------
+            # hasattr(sys,'real_prefix') checks whether the
+            # user is working in python virtual environment
+            #--------------------------------
             if hasattr(sys, 'real_prefix'):
                 self.install_data = os.path.join(sys.prefix, 'etc',
                                                  'jsnapy')
@@ -29,7 +33,7 @@ class OverrideInstall(install):
                                                  'jsnapy')
             else:
                 self.install_data = '/etc/jsnapy'
-            
+
         dir_path = self.install_data
         mode = 0o777
         install.run(self)
@@ -49,29 +53,28 @@ class OverrideInstall(install):
                 for fname in files:
                     os.chmod(os.path.join(root, fname), mode)
 
-        HOME = expanduser("~") #correct cross platform way to do it
-        home_folder = os.path.join(HOME,'.jsnapy')
+        HOME = expanduser("~")  # correct cross platform way to do it
+        home_folder = os.path.join(HOME, '.jsnapy')
         if not os.path.isdir(home_folder):
             os.mkdir(home_folder)
-            os.chmod(home_folder,mode)
-
+            os.chmod(home_folder, mode)
 
         if dir_path != '/etc/jsnapy':
             config = ConfigParser.ConfigParser()
-            config.set('DEFAULT','config_file_path',
+            config.set('DEFAULT', 'config_file_path',
                        dir_path)
-            config.set('DEFAULT','snapshot_path',
-                       os.path.join(dir_path,'snapshots'))
-            config.set('DEFAULT','test_file_path',
-                       os.path.join(dir_path,'testfiles'))
+            config.set('DEFAULT', 'snapshot_path',
+                       os.path.join(dir_path, 'snapshots'))
+            config.set('DEFAULT', 'test_file_path',
+                       os.path.join(dir_path, 'testfiles'))
 
             if hasattr(sys, 'real_prefix'):
                 default_config_location = os.path.join(sys.prefix,
-                                                        'etc',
-                                                        'jsnapy', 'jsnapy.cfg')
+                                                       'etc',
+                                                       'jsnapy', 'jsnapy.cfg')
             elif 'win' in sys.platform:
                 default_config_location = os.path.join(expanduser("~"),
-                                            'jsnapy', 'jsnapy.cfg')
+                                                       'jsnapy', 'jsnapy.cfg')
             else:
                 default_config_location = "/etc/jsnapy/jsnapy.cfg"
 
@@ -90,8 +93,9 @@ class OverrideInstall(install):
                     cfgfile.write(comment)
                     config.write(cfgfile)
             else:
-                raise Exception('jsnapy.cfg not found at '+ default_config_location)
-        
+                raise Exception('jsnapy.cfg not found at ' +
+                                default_config_location)
+
 
 req_lines = [line.strip() for line in open(
     'requirements.txt').readlines()]
@@ -106,14 +110,14 @@ exec(open('lib/jnpr/jsnapy/version.py').read())
 os_data_file = []
 
 if hasattr(sys, 'real_prefix'):
-    home = os.path.join(sys.prefix,'etc')
+    home = os.path.join(sys.prefix, 'etc')
     os_data_file = [(os.path.join(home, 'jsnapy'),
-                    ['lib/jnpr/jsnapy/logging.yml']),
+                     ['lib/jnpr/jsnapy/logging.yml']),
                     (os.path.join(sys.prefix, 'var', 'logs', 'jsnapy'),
                      log_files),
                     ('samples', example_files),
                     (os.path.join(home, 'jsnapy'),
-                    ['lib/jnpr/jsnapy/jsnapy.cfg']),
+                     ['lib/jnpr/jsnapy/jsnapy.cfg']),
                     ('testfiles', ['testfiles/README']),
                     ('snapshots', ['snapshots/README'])
                     ]
@@ -122,11 +126,11 @@ if hasattr(sys, 'real_prefix'):
 elif 'win' in sys.platform:
     home = expanduser("~")
     os_data_file = [(os.path.join(home, 'jsnapy'),
-                    ['lib/jnpr/jsnapy/logging.yml']),
+                     ['lib/jnpr/jsnapy/logging.yml']),
                     (os.path.join(home, 'logs\jsnapy'), log_files),
                     ('samples', example_files),
                     (os.path.join(home, 'jsnapy'),
-                    ['lib/jnpr/jsnapy/jsnapy.cfg']),
+                     ['lib/jnpr/jsnapy/jsnapy.cfg']),
                     ('testfiles', ['testfiles/README']),
                     ('snapshots', ['snapshots/README'])
                     ]
@@ -164,20 +168,20 @@ setup(name="jsnapy",
       data_files=os_data_file,
       cmdclass={'install': OverrideInstall},
       classifiers=[
-          'Environment :: Console',
-          'Intended Audience :: Developers',
-          'Intended Audience :: Information Technology',
-          'Intended Audience :: System Administrators',
-          'Intended Audience :: Telecommunications Industry',
-          'License :: OSI Approved :: Apache Software License',
-          'Operating System :: OS Independent',
-          'Programming Language :: Python',
-          'Programming Language :: Python :: 2.6',
-          'Programming Language :: Python :: 2.7',
-          'Topic :: Software Development :: Libraries',
-          'Topic :: Software Development :: Libraries :: Application Frameworks',
-          'Topic :: Software Development :: Libraries :: Python Modules',
-          'Topic :: System :: Networking',
-          'Topic :: Text Processing :: Markup :: XML'
+        'Environment :: Console',
+        'Intended Audience :: Developers',
+        'Intended Audience :: Information Technology',
+        'Intended Audience :: System Administrators',
+        'Intended Audience :: Telecommunications Industry',
+        'License :: OSI Approved :: Apache Software License',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+        'Topic :: Software Development :: Libraries',
+        'Topic :: Software Development :: Libraries :: Application Frameworks',
+        'Topic :: Software Development :: Libraries :: Python Modules',
+        'Topic :: System :: Networking',
+        'Topic :: Text Processing :: Markup :: XML'
       ],
       )

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ class OverrideInstall(install):
                 break
         else:
             if hasattr(sys, 'real_prefix'):
-                self.install_data = os.path.join(expanduser("~"), '.jsnapy',
+                self.install_data = os.path.join(sys.prefix, 'etc',
                                                  'jsnapy')
             elif 'win' in sys.platform:
                 self.install_data = os.path.join(os.path.expanduser('~'),
@@ -49,11 +49,11 @@ class OverrideInstall(install):
                 for fname in files:
                     os.chmod(os.path.join(root, fname), mode)
 
-        # HOME = expanduser("~") #correct cross platform way to do it
-        # home_folder = os.path.join(HOME,'.jsnapy')
-        # if not os.path.isdir(home_folder):
-        #     os.mkdir(home_folder)
-        #     os.chmod(home_folder,mode)
+        HOME = expanduser("~") #correct cross platform way to do it
+        home_folder = os.path.join(HOME,'.jsnapy')
+        if not os.path.isdir(home_folder):
+            os.mkdir(home_folder)
+            os.chmod(home_folder,mode)
 
 
         if dir_path != '/etc/jsnapy':
@@ -112,10 +112,11 @@ exec(open('lib/jnpr/jsnapy/version.py').read())
 os_data_file = []
 
 if hasattr(sys, 'real_prefix'):
-    home = os.path.join(expanduser("~"),'.jsnapy')
+    home = os.path.join(sys.prefix,'etc')
     os_data_file = [(os.path.join(home, 'jsnapy'),
                     ['lib/jnpr/jsnapy/logging.yml']),
-                    (os.path.join(home, 'logs/jsnapy'), log_files),
+                    (os.path.join(home, 'var', 'logs', 'jsnapy'),
+                     log_files),
                     ('samples', example_files),
                     (os.path.join(home, 'jsnapy'),
                     ['lib/jnpr/jsnapy/jsnapy.cfg']),

--- a/setup.py
+++ b/setup.py
@@ -66,38 +66,32 @@ class OverrideInstall(install):
                        os.path.join(dir_path,'testfiles'))
 
             if hasattr(sys, 'real_prefix'):
-                default_config_location = [os.path.join(sys.prefix,
+                default_config_location = os.path.join(sys.prefix,
                                                         'etc',
-                                                        'jsnapy', 'jsnapy.cfg'),
-                                            os.path.join
-                                           (expanduser("~"),
-                                            'jsnapy', 'jsnapy.cfg'),
-                                           "/etc/jsnapy/jsnapy.cfg"
-                                          ]
+                                                        'jsnapy', 'jsnapy.cfg')
+            elif 'win' in sys.platform:
+                default_config_location = os.path.join(expanduser("~"),
+                                            'jsnapy', 'jsnapy.cfg')
             else:
-                default_config_location = [os.path.join(expanduser("~"),
-                                                        'jsnapy', 'jsnapy.cfg'),
-                                           "/etc/jsnapy/jsnapy.cfg"]
+                default_config_location = "/etc/jsnapy/jsnapy.cfg"
 
-            flag = False
-            for possible_location in default_config_location:
-                if os.path.isfile(possible_location):
-                    with open(possible_location, 'w') as cfgfile:
-                        comment = ('# This file can be overwritten\n'
-                                   '# It contains default path for\n'
-                                   '# config file, snapshots and testfiles\n'
-                                   '# If required, overwrite the path with'
-                                   '# your path\n'
-                                   '# config_file_path: path of main'
-                                   '# config file\n'
-                                   '# snapshot_path : path of snapshot file\n'
-                                   '# test_file_path: path of test file\n\n'
-                                   )
-                        cfgfile.write(comment)
-                        config.write(cfgfile)
-                        flag = True
-            if flag is False:
-                raise Exception('jsnapy.cfg not found at possible location')
+            if os.path.isfile(default_config_location):
+                with open(default_config_location, 'w') as cfgfile:
+                    comment = ('# This file can be overwritten\n'
+                               '# It contains default path for\n'
+                               '# config file, snapshots and testfiles\n'
+                               '# If required, overwrite the path with'
+                               '# your path\n'
+                               '# config_file_path: path of main'
+                               '# config file\n'
+                               '# snapshot_path : path of snapshot file\n'
+                               '# test_file_path: path of test file\n\n'
+                               )
+                    cfgfile.write(comment)
+                    config.write(cfgfile)
+                    flag = True
+            else:
+                raise Exception('jsnapy.cfg not found at %s',default_config_location)
         
 
 req_lines = [line.strip() for line in open(

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -31,19 +31,19 @@ class TestCheck(unittest.TestCase):
         loc = get_config_location()
         self.assertEqual(loc, os.path.join('bogus', 'path'))
     
-    # @patch('os.path.isfile')
-    # def test_config_location_home(self, mock_is_file):
-    #     mock_is_file.side_effect = lambda arg: arg == os.path.join(os.path.expanduser('~'),'.jsnapy','jsnapy.cfg')
-    #     loc = get_config_location()
-    #     self.assertEqual(loc,os.path.join(os.path.expanduser('~'),'.jsnapy'))
+    @patch('os.path.isfile')
+    def test_config_location_home(self, mock_is_file):
+        mock_is_file.side_effect = lambda arg: arg == os.path.join(os.path.expanduser('~'),'.jsnapy','jsnapy.cfg')
+        loc = get_config_location()
+        self.assertEqual(loc,os.path.join(os.path.expanduser('~'),'.jsnapy'))
 
     @patch('os.path.isfile')
     def test_config_location_etc(self, mock_is_file):
         if hasattr(sys, 'real_prefix'):
-            mock_is_file.side_effect = lambda arg: arg in [os.path.join(os.path.expanduser('~'), '.jsnapy',
+            mock_is_file.side_effect = lambda arg: arg in [os.path.join(sys.prefix, 'etc',
                                                                         'jsnapy', 'jsnapy.cfg')]
             loc = get_config_location()
-            self.assertEqual(loc, os.path.join(os.path.expanduser('~'), '.jsnapy', 'jsnapy'))
+            self.assertEqual(loc, os.path.join(sys.prefix, 'etc', 'jsnapy'))
         elif 'win' in sys.platform:
             mock_is_file.side_effect = lambda arg: arg in [os.path.join(os.path.expanduser('~'),
                                                                         'jsnapy', 'jsnapy.cfg')]


### PR DESCRIPTION
Rollback to the directory structure->

In Python virtual environment, lets say venv:
inside venv creating 2 directories : 
- venv/etc/jsnapy/   for all sample files
- venv/var/logs/jsnapy/ for all logging

for windows in the Home directory,
Creating 2 directories:
- ~/jsnapy/ for all sample files
- ~/logs/jsnapy/ for all logging