### PR TITLE
changing win to win32

### DIFF
--- a/lib/jnpr/jsnapy/__init__.py
+++ b/lib/jnpr/jsnapy/__init__.py
@@ -24,7 +24,7 @@ def get_config_location(file='jsnapy.cfg'):
     if hasattr(sys, 'real_prefix'):
         p_locations.extend([os.path.join(os.path.expanduser("~"), '.jsnapy'),
                             os.path.join(sys.prefix, 'etc', 'jsnapy')])
-    elif 'win' in sys.platform:
+    elif 'win32' in sys.platform:
         p_locations.extend(
             [os.path.join(os.path.expanduser("~"), '.jsnapy'),
              os.path.join(os.path.expanduser('~'), 'jsnapy')])

--- a/lib/jnpr/jsnapy/setup_logging.py
+++ b/lib/jnpr/jsnapy/setup_logging.py
@@ -31,7 +31,7 @@ def setup_logging(
                         value['filename'] = (os.path.join
                                              (sys.prefix,
                                               'var/logs/jsnapy/jsnapy.log'))
-                    elif 'win' in sys.platform:
+                    elif 'win32' in sys.platform:
                         value['filename'] = (os.path.join
                                              (os.path.expanduser('~'),
                                               'logs\jsnapy\jsnapy.log'))

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ class OverrideInstall(install):
             if hasattr(sys, 'real_prefix'):
                 self.install_data = os.path.join(sys.prefix, 'etc',
                                                  'jsnapy')
-            elif 'win' in sys.platform:
+            elif 'win32' in sys.platform:
                 self.install_data = os.path.join(os.path.expanduser('~'),
                                                  'jsnapy')
             else:
@@ -41,7 +41,7 @@ class OverrideInstall(install):
         mode = 0o777
         install.run(self)
 
-        if 'win' not in sys.platform and not hasattr(sys, 'real_prefix'):
+        if 'win32' not in sys.platform and not hasattr(sys, 'real_prefix'):
             os.chmod(dir_path, mode)
             for root, dirs, files in os.walk(dir_path):
                 for directory in dirs:
@@ -75,7 +75,7 @@ class OverrideInstall(install):
                 default_config_location = os.path.join(sys.prefix,
                                                        'etc',
                                                        'jsnapy', 'jsnapy.cfg')
-            elif 'win' in sys.platform:
+            elif 'win32' in sys.platform:
                 default_config_location = os.path.join(expanduser("~"),
                                                        'jsnapy', 'jsnapy.cfg')
             else:
@@ -126,7 +126,7 @@ if hasattr(sys, 'real_prefix'):
                     ]
 
 
-elif 'win' in sys.platform:
+elif 'win32' in sys.platform:
     home = expanduser("~")
     os_data_file = [(os.path.join(home, 'jsnapy'),
                      ['lib/jnpr/jsnapy/logging.yml']),

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -42,7 +42,7 @@ class TestCheck(unittest.TestCase):
                                                       'jsnapy.cfg')]
             loc = get_config_location()
             self.assertEqual(loc, os.path.join(sys.prefix, 'etc', 'jsnapy'))
-        elif 'win' in sys.platform:
+        elif 'win32' in sys.platform:
             mock_is_file.side_effect = lambda arg: arg in [os.path.join(os.path.expanduser('~'),
                                                                         'jsnapy', 'jsnapy.cfg')]
             loc = get_config_location()
@@ -76,7 +76,7 @@ class TestCheck(unittest.TestCase):
     @patch('jnpr.jsnapy.get_config_location')
     def test_get_path_custom(self, mock_config_loc):
         DirStore.custom_dir = '~/bogus'
-        if 'win' in sys.platform:
+        if 'win32' in sys.platform:
             HOME = os.path.join(os.path.expanduser('~'), 'bogus\\')
         else:
             HOME = os.path.join(os.path.expanduser('~'), 'bogus/')


### PR DESCRIPTION
#266 issue resolved in this commit. The reason of installation fail was due to the 'win' getting detected in darwin and hence was getting installed the windows way. So changing the 'win' to 'win32'.