### PR TITLE
Fix race condition in reading the logging configuration file. Fixes #263

### DIFF
--- a/lib/jnpr/jsnapy/setup_logging.py
+++ b/lib/jnpr/jsnapy/setup_logging.py
@@ -35,9 +35,6 @@ def setup_logging(
                         value['filename'] = (os.path.join
                                              (os.path.expanduser('~'),
                                               'logs\jsnapy\jsnapy.log'))
-
-                with open(path, "w") as f:
-                    yaml.dump(config, f, default_flow_style=False)
         logging.config.dictConfig(config)
     else:
         logging.basicConfig(level=default_level)


### PR DESCRIPTION
See analysis [here](https://github.com/Juniper/jsnapy/issues/263#issuecomment-332898969).