### PR TITLE
Including kwargs in file name for snapshot

### DIFF
--- a/lib/jnpr/jsnapy/check.py
+++ b/lib/jnpr/jsnapy/check.py
@@ -17,6 +17,8 @@ from jnpr.jsnapy.sqlite_get import SqliteExtractXml
 from icdiff import diff, codec_print, get_options, ConsoleDiff
 from jnpr.jsnapy.xml_comparator import XmlComparator
 from jnpr.jsnapy import get_path
+import hashlib
+import bencode
 
 
 class Comparator:
@@ -560,6 +562,12 @@ class Comparator:
         op.device = device
         tests_files = []
         self.log_detail['hostname'] = device
+        # pre_user and post_user are the names of the snapshot files
+        # that the user wants to keep and store the snapfiles
+        # with these names
+        pre_user = pre
+        post_user = post
+
         # get the test files from config.yml
         if main_file.get('tests') is None:
             self.logger_check.error(
@@ -613,6 +621,12 @@ class Comparator:
                         
                             name = '_'.join(command.split())
                             teston = command
+
+                            # this is necessary for the pre and post to be the same that user specified
+                            # In a case when there are multiple rpc's and a command then this is necessary
+
+                            pre = pre_user
+                            post = post_user
                         else:
                             rpc = tests[val][0]['rpc']
                             reply_format = tests[val][0].get('format', 'xml')
@@ -620,6 +634,22 @@ class Comparator:
                                                    rpc + (25) * '*', extra=self.log_detail)
                             name = rpc
                             teston = rpc
+
+                            # this is necessary for the pre and post to be the same that user specified
+                            # In a case when there are multiple rpc's with kwargs and a rpc with no kwargs
+                            pre = pre_user
+                            post = post_user
+
+                            # here the user specified name is being used and the hash value generated for
+                            # kwargs part is appended to the name
+                            if 'kwargs' in tests[val][1]:
+                                data = tests[val][1].get('kwargs')
+                                hash_kwargs = hashlib.md5(bencode.bencode(data)).hexdigest()
+                                if action == 'check' and pre_user is not None and post_user is not None:
+                                    pre = pre_user + '_' + hash_kwargs
+                                    post = post_user + '_' + hash_kwargs
+                                elif action == 'snapcheck' and pre_user is not None and post_user is None:
+                                    pre = pre_user + '_' + hash_kwargs
                     except KeyError:
                         self.logger_check.error(
                             colorama.Fore.RED +

--- a/lib/jnpr/jsnapy/check.py
+++ b/lib/jnpr/jsnapy/check.py
@@ -18,7 +18,7 @@ from icdiff import diff, codec_print, get_options, ConsoleDiff
 from jnpr.jsnapy.xml_comparator import XmlComparator
 from jnpr.jsnapy import get_path
 import hashlib
-import bencode
+import json
 
 
 class Comparator:
@@ -644,7 +644,7 @@ class Comparator:
                             # kwargs part is appended to the name
                             if 'kwargs' in tests[val][1]:
                                 data = tests[val][1].get('kwargs')
-                                hash_kwargs = hashlib.md5(bencode.bencode(data)).hexdigest()
+                                hash_kwargs = hashlib.md5(json.dumps(data, sort_keys=True).encode('utf-8')).hexdigest()
                                 if action == 'check' and pre_user is not None and post_user is not None:
                                     pre = pre_user + '_' + hash_kwargs
                                     post = post_user + '_' + hash_kwargs

--- a/lib/jnpr/jsnapy/check.py
+++ b/lib/jnpr/jsnapy/check.py
@@ -642,7 +642,14 @@ class Comparator:
 
                             # here the user specified name is being used and the hash value generated for
                             # kwargs part is appended to the name
-                            if 'kwargs' or 'args' in tests[val][1]:
+
+                            if 'kwargs' in tests[val][1] and tests[val][1].get('kwargs') is None:
+                                del tests[val][1]['kwargs']
+
+                            if 'args' in tests[val][1] and tests[val][1].get('args') is None:
+                                del tests[val][1]['args']
+
+                            if 'kwargs' in tests[val][1] or 'args' in tests[val][1]:
                                 if tests[val][1].get('kwargs'):
                                     data = tests[val][1].get('kwargs')
                                 elif tests[val][1].get('args'):

--- a/lib/jnpr/jsnapy/check.py
+++ b/lib/jnpr/jsnapy/check.py
@@ -642,8 +642,11 @@ class Comparator:
 
                             # here the user specified name is being used and the hash value generated for
                             # kwargs part is appended to the name
-                            if 'kwargs' in tests[val][1]:
-                                data = tests[val][1].get('kwargs')
+                            if 'kwargs' or 'args' in tests[val][1]:
+                                if tests[val][1].get('kwargs'):
+                                    data = tests[val][1].get('kwargs')
+                                elif tests[val][1].get('args'):
+                                    data = tests[val][1].get('args')
                                 hash_kwargs = hashlib.md5(json.dumps(data, sort_keys=True).encode('utf-8')).hexdigest()
                                 if action == 'check' and pre_user is not None and post_user is not None:
                                     pre = pre_user + '_' + hash_kwargs

--- a/lib/jnpr/jsnapy/snap.py
+++ b/lib/jnpr/jsnapy/snap.py
@@ -15,6 +15,8 @@ from jnpr.jsnapy import get_path
 from jnpr.junos.exception import RpcError
 from jnpr.jsnapy.sqlite_store import JsnapSqlite
 import lxml
+import hashlib
+import bencode
 
 
 class Parser:
@@ -393,14 +395,27 @@ class Parser:
                         hostname,
                         db)
                 elif test_file.get(t) is not None and 'rpc' in test_file[t][0]:
-                    self.run_rpc(
+                    if 'kwargs' in test_file[t][1]:
+                        data = test_file[t][1].get('kwargs')
+                        data_md5 = hashlib.md5(bencode.bencode(data)).hexdigest()
+
+                        self.run_rpc(
                         test_file,
                         t,
                         formats,
                         dev,
-                        output_file,
+                        output_file + '_' + data_md5,
                         hostname,
                         db)
+                    else:
+                        self.run_rpc(
+                            test_file,
+                            t,
+                            formats,
+                            dev,
+                            output_file,
+                            hostname,
+                            db)
                 else:
                     self.logger_snap.error(
                         colorama.Fore.RED +

--- a/lib/jnpr/jsnapy/snap.py
+++ b/lib/jnpr/jsnapy/snap.py
@@ -16,7 +16,7 @@ from jnpr.junos.exception import RpcError
 from jnpr.jsnapy.sqlite_store import JsnapSqlite
 import lxml
 import hashlib
-import bencode
+import json
 
 
 class Parser:
@@ -397,7 +397,7 @@ class Parser:
                 elif test_file.get(t) is not None and 'rpc' in test_file[t][0]:
                     if 'kwargs' in test_file[t][1]:
                         data = test_file[t][1].get('kwargs')
-                        data_md5 = hashlib.md5(bencode.bencode(data)).hexdigest()
+                        data_md5 = hashlib.md5(json.dumps(data, sort_keys=True).encode('utf-8')).hexdigest()
 
                         self.run_rpc(
                         test_file,

--- a/lib/jnpr/jsnapy/snap.py
+++ b/lib/jnpr/jsnapy/snap.py
@@ -395,7 +395,13 @@ class Parser:
                         hostname,
                         db)
                 elif test_file.get(t) is not None and 'rpc' in test_file[t][0]:
-                    if 'kwargs' or 'args' in test_file[t][1]:
+                    if 'kwargs' in test_file[t][1] and test_file[t][1].get('kwargs') is None:
+                        del test_file[t][1]['kwargs']
+
+                    if 'args' in test_file[t][1] and test_file[t][1].get('args') is None:
+                        del test_file[t][1]['args']
+
+                    if 'kwargs' in test_file[t][1] or 'args' in test_file[t][1]:
                         if test_file[t][1].get('kwargs'):
                             data = test_file[t][1].get('kwargs')
                         elif test_file[t][1].get('args'):

--- a/lib/jnpr/jsnapy/snap.py
+++ b/lib/jnpr/jsnapy/snap.py
@@ -395,16 +395,19 @@ class Parser:
                         hostname,
                         db)
                 elif test_file.get(t) is not None and 'rpc' in test_file[t][0]:
-                    if 'kwargs' in test_file[t][1]:
-                        data = test_file[t][1].get('kwargs')
-                        data_md5 = hashlib.md5(json.dumps(data, sort_keys=True).encode('utf-8')).hexdigest()
+                    if 'kwargs' or 'args' in test_file[t][1]:
+                        if test_file[t][1].get('kwargs'):
+                            data = test_file[t][1].get('kwargs')
+                        elif test_file[t][1].get('args'):
+                            data = test_file[t][1].get('args')
+                        hash_kwargs = hashlib.md5(json.dumps(data, sort_keys=True).encode('utf-8')).hexdigest()
 
                         self.run_rpc(
                         test_file,
                         t,
                         formats,
                         dev,
-                        output_file + '_' + data_md5,
+                        output_file + '_' + hash_kwargs,
                         hostname,
                         db)
                     else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ configparser
 pyparsing
 icdiff
 future
+bencode

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ configparser
 pyparsing
 icdiff
 future
-bencode

--- a/tests/unit/test_snap.py
+++ b/tests/unit/test_snap.py
@@ -425,16 +425,17 @@ class TestSnap(unittest.TestCase):
                 self.db)
             db_dict = dict()
             db_dict['cli_command'] = 'get-config'
-            db_dict['snap_name'] = "snap_mock"
+            db_dict['snap_name'] = "snap_mock_b5cc63f545240eeeb3f89bf9bc14c1b4"
             db_dict['filename'] = "1.1.1.1" + "_" + \
-                "snap_mock" + "_" + "get-config" + "." + "xml"
+                "snap_mock_b5cc63f545240eeeb3f89bf9bc14c1b4" + "_" + "get-config" + "." + "xml"
             db_dict['format'] = 'xml'
             db_dict['data'] = mock_reply()
             calls.append(call(db_dict))
             db_dict2 = db_dict.copy()
+            db_dict2['snap_name'] = "snap_mock_f04ff3f94a71ab32aea2b2f237ae9f60"
             db_dict2['cli_command'] = 'get-interface-information'
             db_dict2['filename'] = "1.1.1.1" + "_" + \
-                "snap_mock" + "_" + "get-interface-information" + "." + "xml"
+                "snap_mock_f04ff3f94a71ab32aea2b2f237ae9f60" + "_" + "get-interface-information" + "." + "xml"
             calls.append(call(db_dict2))
             mock_insert.assert_has_calls(calls)
         dev.close()


### PR DESCRIPTION
Should Fix #233 
This pull request will handle issues where for the same rpc but different kwargs only one snapshot according to the last executed rpc was stored. Now for every rpc with kwargs will be stored in a different file. A hashvalue will be calculated for the kwargs dictionary and appended to the name the user wants to give to the snapshot.

Following example will explain the changes:

main.yml
```
hosts:
  - device: 1.1.1.1
    username : abc
    passwd: xyz

tests:
  - test_1.yml
```

test_1.yml

```
test_interfaces_terse:
  - rpc: get-interface-information
  - kwargs:
      interface-name: cbp0
      media: True
  - iterate:
      xpath: //physical-interface
      tests:
        - is-equal: admin-status, up
          info: "Test Succeeded !! admin-status is equal to {{pre['admin-status']}} with oper-status {{pre['oper-status']}}"
          err: "Test Failed !! admin-status is not equal to up, it is {{pre['admin-status']}} with oper-status {{pre['oper-status']}}"


test_interfaces_terse_1:
  - rpc: get-interface-information
  - kwargs:
      interface-name: cbp0
  - iterate:
      xpath: //physical-interface
      tests:
        - is-equal: admin-status, up
          info: "Test Succeeded !! admin-status is equal to {{pre['admin-status']}} with oper-status {{pre['oper-status']}}"
          err: "Test Failed !! admin-status is not equal to up, it is {{pre['admin-status']}} with oper-status {{pre['oper-status']}}"

test_interfaces_terse_2:
  - rpc: get-interface-information
  - kwargs:
      interface-name: cbp0
      media: True
      terse: True
  - iterate:
      xpath: //physical-interface
      tests:
        - is-equal: admin-status, up
          info: "Test Succeeded !! admin-status is equal to {{pre['admin-status']}} with oper-status {{pre['oper-status']}}"
          err: "Test Failed !! admin-status is not equal to up, it is {{pre['admin-status']}} with oper-status {{pre['oper-status']}}"

test_interfaces_terse_3:
  - command: show interfaces
  - iterate:
      xpath: //physical-interface
      tests:
        - is-equal: admin-status, up
          info: "Test Succeeded !! admin-status is equal to {{pre['admin-status']}} with oper-status {{pre['oper-status']}}"
          err: "Test Failed !! admin-status is not equal to up, it is {{pre['admin-status']}} with oper-status {{pre['oper-status']}}"

test_interfaces_terse_4:
  - rpc: get-interface-information
  - iterate:
      xpath: //physical-interface
      tests:
        - is-equal: admin-status, up
          info: "Test Succeeded !! admin-status is equal to {{pre['admin-status']}} with oper-status {{pre['oper-status']}}"
          err: "Test Failed !! admin-status is not equal to up, it is {{pre['admin-status']}} with oper-status {{pre['oper-status']}}"

```

On running the above with:
```
jsnapy --snap post -f main.yml
```

See that there are different hashes generated for different kwargs, and if no kwargs are present for the rpc the name of the file would be without the hashvalue. The filename adjustment remains the same for command which doesn't support the kwargs.


```
1.1.1.1_post_2d44e066d1e43f9155a30867fcc28cc3_get_interface_information.xml
1.1.1.1_post_56c7603b198874959eee14719354a9e5_get_interface_information.xml
1.1.1.1_post_baaabbb839301f6795c3bb004a87b6b8_get_interface_information.xml
1.1.1.1_post_get_interface_information.xml
1.1.1.1_post_show_interfaces.xml
```