### PR TITLE
changing security permissions for /etc/jsnapy and /var/log/jsnapy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,29 +63,31 @@ class OverrideInstall(install):
                 self.install_data = '/etc/jsnapy'
 
         dir_path = self.install_data
-        mode = 0o777
+        dir_mode = 0o755
+        file_mode = 0o644
         install.run(self)
 
         if 'win32' not in sys.platform and not hasattr(sys, 'real_prefix'):
-            os.chmod(dir_path, mode)
+            os.chmod(dir_path, dir_mode)
             for root, dirs, files in os.walk(dir_path):
                 for directory in dirs:
-                    os.chmod(os.path.join(root, directory), mode)
+                    os.chmod(os.path.join(root, directory), dir_mode)
                 for fname in files:
-                    os.chmod(os.path.join(root, fname), mode)
+                    os.chmod(os.path.join(root, fname), file_mode)
 
-            os.chmod('/var/log/jsnapy', mode)
+            os.chmod('/var/log/jsnapy', dir_mode)
             for root, dirs, files in os.walk('/var/log/jsnapy'):
                 for directory in dirs:
-                    os.chmod(os.path.join(root, directory), mode)
+                    os.chmod(os.path.join(root, directory), dir_mode)
                 for fname in files:
-                    os.chmod(os.path.join(root, fname), mode)
+                    os.chmod(os.path.join(root, fname), file_mode)
 
         HOME = expanduser("~")  # correct cross platform way to do it
         home_folder = os.path.join(HOME, '.jsnapy')
+        user_mode = 0o777
         if not os.path.isdir(home_folder):
             os.mkdir(home_folder)
-            os.chmod(home_folder, mode)
+            os.chmod(home_folder, user_mode)
 
         if dir_path != '/etc/jsnapy':
             config = ConfigParser()


### PR DESCRIPTION
As per the current process of installation of JSNAPy, there are files and directories that are created for the use of JSNAPy. Currently the /etc/jsnapy and /var/log/jsnapy folder's are being created with permissions as follows:
```
bash-3.2# ls -ltr /etc/jsnapy
total 16
-rwxrwxrwx   1 root  wheel  1695 Oct  3 11:17 logging.yml
-rwxrwxrwx   1 root  wheel   387 Oct  3 11:17 jsnapy.cfg
drwxrwxrwx   3 root  wheel   102 Oct 31 14:49 testfiles
drwxrwxrwx  46 root  wheel  1564 Oct 31 14:49 samples
drwxrwxrwx   4 root  wheel   136 Oct 31 14:50 snapshots
```

```
bash-3.2# ls -ltr /var/log/jsnapy/
total 8
-rwxrwxrwx  1 root  wheel     0 Oct  3 11:17 info.log
-rwxrwxrwx  1 root  wheel     0 Oct  3 11:17 errors.log
-rwxrwxrwx  1 root  wheel     0 Oct  3 11:17 debug.log
-rwxrwxrwx  1 root  wheel     0 Oct  3 11:17 critical.log
-rwxrwxrwx  1 root  wheel     0 Oct  3 11:17 __init__.py
-rwxrwxrwx 1 root  wheel  1604 Oct 31 14:50 jsnapy.log
```
after this merge the scenario will be somewhat like this:
```
bash-3.2# ls -ltr /etc/jsnapy
total 16
-rw-r--r--   1 root  wheel  1695 Oct  3 11:17 logging.yml
-rw-r--r--   1 root  wheel   387 Oct  3 11:17 jsnapy.cfg
drwxr-xr-x   3 root  wheel   102 Oct 31 14:49 testfiles
drwxr-xr-x  46 root  wheel  1564 Oct 31 14:49 samples
drwxr-xr-x   4 root  wheel   136 Oct 31 14:50 snapshots
```

```
bash-3.2# ls -ltr /var/log/jsnapy/
total 8
-rw-r--r--  1 root  wheel     0 Oct  3 11:17 info.log
-rw-r--r--  1 root  wheel     0 Oct  3 11:17 errors.log
-rw-r--r--  1 root  wheel     0 Oct  3 11:17 debug.log
-rw-r--r--  1 root  wheel     0 Oct  3 11:17 critical.log
-rw-r--r--  1 root  wheel     0 Oct  3 11:17 __init__.py
-rw-r--r--  1 root  wheel  1604 Oct 31 14:50 jsnapy.log
```

This will allow the writing permissions to these folder's only for the root. So only root will be able to use system-wide installed JSNAPy. 

**For all the non-root user's there is the virtualenv support available which is independent of these folder permission's.**

More info on installation in python virtualenvironment installation can be found in [https://github.com/Juniper/jsnapy/wiki#python-virtualenv-support](url)