### PR TITLE
FIX #284 Fixing double output when no password provided

### DIFF
--- a/lib/jnpr/jsnapy/jsnapy.py
+++ b/lib/jnpr/jsnapy/jsnapy.py
@@ -664,7 +664,7 @@ class SnapAdmin:
                     password = getpass.getpass(
                         "\nEnter Password for username <%s> : " %
                         username)
-                    self.connect(
+                    return self.connect(
                         hostname,
                         username,
                         password,


### PR DESCRIPTION
Fix #284 

After it hits ConnectAuthError with password is None it calls _connect_ second time from the beginning with updated arguments.
There  is no need to do the rest of the initial call, but it needs to return the result. So _return_ added.

```
def connect(self, hostname, username, password, output_file,
                config_data=None, action=None, post_snap=None, **kwargs):
...
...
except ConnectAuthError as ex:
                if password is None and action is None:
                    password = getpass.getpass(
                        "\nEnter Password for username <%s> : " %
                        username)
                    self.connect(
                        hostname,
                        username,
                        password,
                        output_file,
                        config_data,
                        action,
                        post_snap,
                        **kwargs)
....
```