### PR TITLE
import error for yaml

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,13 +14,12 @@ if sys.version < '3':
     from ConfigParser import ConfigParser
 else:
     from configparser import ConfigParser
-
-import yaml
 from six import iteritems
 
 
 def set_logging_path(path):
     if os.path.exists(path):
+        import yaml
         with open(path, 'rt') as f:
             config = yaml.load(f.read())
 


### PR DESCRIPTION
While installing jsnapy if yaml module is not installed on device, would give import error. Moving the API call to yaml module to the local function.