### PR TITLE
Fix #187

### DIFF
--- a/lib/jnpr/jsnapy/check.py
+++ b/lib/jnpr/jsnapy/check.py
@@ -626,8 +626,9 @@ class Comparator:
                         (val),
                         extra=self.log_detail)
                     try:
-                        if 'command' in list(tests[val][0].keys()):
-                            command = tests[val][0].get('command').split('|')[0].strip()
+                        if any('command' in d for d in tests[val]):
+                            index = next((i for i, x in enumerate(tests[val]) if 'command' in x), 0)
+                            command = tests[val][index].get('command').split('|')[0].strip()
                             reply_format = tests[val][0].get('format', 'xml')
                             message = self._print_testmssg("Command: "+command, "*")
                         
@@ -644,8 +645,11 @@ class Comparator:
                             pre = pre_user
                             post = post_user
                         else:
-                            rpc = tests[val][0]['rpc']
-                            reply_format = tests[val][0].get('format', 'xml')
+                            index = next((i for i, x in enumerate(tests[val]) if 'rpc' in x), 0)
+                            index_kwargs = next((i for i, x in enumerate(tests[val]) if 'kwargs' in x or 'args' in x),
+                                                1)
+                            rpc = tests[val][index]['rpc']
+                            reply_format = tests[val][index].get('format', 'xml')
                             self.logger_check.info(colorama.Fore.BLUE + (25) * "*" + "RPC is " +
                                                    rpc + (25) * '*', extra=self.log_detail)
                             name = rpc
@@ -658,17 +662,17 @@ class Comparator:
                             # here the user specified name is being used and the hash value generated for
                             # kwargs part is appended to the name
 
-                            if 'kwargs' in tests[val][1] and tests[val][1].get('kwargs') is None:
-                                del tests[val][1]['kwargs']
+                            if 'kwargs' in tests[val][index_kwargs] and tests[val][index_kwargs].get('kwargs') is None:
+                                del tests[val][index_kwargs]['kwargs']
 
-                            if 'args' in tests[val][1] and tests[val][1].get('args') is None:
-                                del tests[val][1]['args']
+                            if 'args' in tests[val][index_kwargs] and tests[val][index_kwargs].get('args') is None:
+                                del tests[val][index_kwargs]['args']
 
-                            if 'kwargs' in tests[val][1] or 'args' in tests[val][1]:
-                                if tests[val][1].get('kwargs'):
-                                    data = tests[val][1].get('kwargs')
-                                elif tests[val][1].get('args'):
-                                    data = tests[val][1].get('args')
+                            if 'kwargs' in tests[val][index_kwargs] or 'args' in tests[val][index_kwargs]:
+                                if tests[val][index_kwargs].get('kwargs'):
+                                    data = tests[val][index_kwargs].get('kwargs')
+                                elif tests[val][index_kwargs].get('args'):
+                                    data = tests[val][index_kwargs].get('args')
                                 hash_kwargs = hashlib.md5(json.dumps(data, sort_keys=True).encode('utf-8')).digest()
                                 hash_kwargs = base64.urlsafe_b64encode(hash_kwargs).strip()
                                 if action == 'check' and pre_user is not None and post_user is not None:

--- a/tests/unit/configs/conditional_op_pass.yml
+++ b/tests/unit/configs/conditional_op_pass.yml
@@ -3,7 +3,6 @@ tests_include:
 
 # for simple, one test using command
 test_command_version:
-  - command: show bgp neighbor
   - iterate:
       xpath: '/bgp-information/bgp-peer'
       id: peer-address
@@ -17,5 +16,6 @@ test_command_version:
               - NOT:
                   - contains: //bgp-options, LogUpDown
               - is-equal: local-address, unspecified
+  - command: show bgp neighbor
             
               

--- a/tests/unit/test_snap.py
+++ b/tests/unit/test_snap.py
@@ -440,111 +440,113 @@ class TestSnap(unittest.TestCase):
             mock_insert.assert_has_calls(calls)
         dev.close()
 
-        @patch('logging.Logger.info')
-        def test_write_file(self, mock_info):
-            par = Parser()
-            res = par._check_reply(True, 'xml')
-            self.assertEqual(res, '')
-            mock_info.assert_called()
+    @patch('logging.Logger.info')
+    def test_write_file(self, mock_info):
+        par = Parser()
+        res = par._check_reply(True, 'xml')
+        self.assertEqual(res, '')
+        mock_info.assert_called()
 
-        @patch('logging.Logger.error')
-        @patch('ncclient.manager.connect')
-        def test_generate_reply_error_1(self, mock_dev, mock_err):
-            par = Parser()
-            test_file = os.path.join(os.path.dirname(__file__),
-                                     'configs', 'bogus_testfile_1.yml')
-            test_file = open(test_file, 'r')
-            test_file = yaml.load(test_file)
-            dev = Device(user='1.1.1.1', host='abc', passwd='xyz')
-            dev.open()
-            par.generate_reply(test_file, dev, '1.1.1.1_snap_mock', self.hostname, self.db)
-            mock_err.assert_called()
+    @patch('logging.Logger.error')
+    @patch('ncclient.manager.connect')
+    def test_generate_reply_error_1(self, mock_dev, mock_err):
+        par = Parser()
+        test_file = os.path.join(os.path.dirname(__file__),
+                                 'configs', 'bogus_testfile_1.yml')
+        test_file = open(test_file, 'r')
+        test_file = yaml.load(test_file)
+        dev = Device(user='1.1.1.1', host='abc', passwd='xyz')
+        dev.open()
+        par.generate_reply(test_file, dev, '1.1.1.1_snap_mock', self.hostname, self.db)
+        mock_err.assert_called()
 
-        @patch('logging.Logger.error')
-        @patch('ncclient.manager.connect')
-        def test_generate_reply_error_2(self, mock_dev, mock_err):
-            par = Parser()
-            test_file = os.path.join(os.path.dirname(__file__),
-                                     'configs', 'bogus_testfile_2.yml')
-            test_file = open(test_file, 'r')
-            test_file = yaml.load(test_file)
-            dev = Device(user='1.1.1.1', host='abc', passwd='xyz')
-            dev.open()
-            par.generate_reply(test_file, dev, '1.1.1.1_snap_mock', self.hostname, self.db)
-            mock_err.assert_called()
+    @patch('logging.Logger.error')
+    @patch('ncclient.manager.connect')
+    def test_generate_reply_error_2(self, mock_dev, mock_err):
+        par = Parser()
+        test_file = os.path.join(os.path.dirname(__file__),
+                                 'configs', 'bogus_testfile_2.yml')
+        test_file = open(test_file, 'r')
+        test_file = yaml.load(test_file)
+        dev = Device(user='1.1.1.1', host='abc', passwd='xyz')
+        dev.open()
+        par.generate_reply(test_file, dev, '1.1.1.1_snap_mock', self.hostname, self.db)
+        mock_err.assert_called()
 
-        @patch('jnpr.jsnapy.snap.Parser._write_warning')
-        @patch('jnpr.junos.rpcmeta._RpcMetaExec.cli')
-        @patch('logging.Logger.error')
-        @patch('lxml.etree.tostring')
-        @patch('ncclient.manager.connect')
-        def test_generate_reply_error_3(self, mock_dev, mock_tostring, mock_err, mock_cli, mock_write_warn):
-            from jnpr.junos.exception import RpcError
-            mock_cli.side_effect = RpcError
-            par = Parser()
-            test_file = os.path.join(os.path.dirname(__file__),
-                                     'configs', 'bogus_testfile_3.yml')
-            test_file = open(test_file, 'r')
-            test_file = yaml.load(test_file)
-            dev = Device(host='10.221.136.250', user='abc', passwd='xyz')
-            dev.open()
-            par.generate_reply(test_file, dev, 'mock.xml', self.hostname, self.db)
-            mock_err.assert_called()
-            mock_write_warn.assert_called()
+    @patch('jnpr.jsnapy.snap.Parser._write_warning')
+    @patch('jnpr.junos.rpcmeta._RpcMetaExec.cli')
+    @patch('logging.Logger.error')
+    @patch('lxml.etree.tostring')
+    @patch('ncclient.manager.connect')
+    def test_generate_reply_error_3(self, mock_dev, mock_tostring, mock_err, mock_cli, mock_write_warn):
+        from jnpr.junos.exception import RpcError
+        mock_cli.side_effect = RpcError
+        par = Parser()
+        test_file = os.path.join(os.path.dirname(__file__),
+                                 'configs', 'bogus_testfile_3.yml')
+        test_file = open(test_file, 'r')
+        test_file = yaml.load(test_file)
+        dev = Device(host='10.221.136.250', user='abc', passwd='xyz')
+        dev.open()
+        par.generate_reply(test_file, dev, 'mock.xml', self.hostname, self.db)
+        mock_err.assert_called()
+        mock_write_warn.assert_called()
 
-        @patch('jnpr.jsnapy.snap.Parser._write_warning')
-        @patch('jnpr.junos.rpcmeta._RpcMetaExec.__getattr__')
-        @patch('logging.Logger.error')
-        @patch('lxml.etree.tostring')
-        @patch('ncclient.manager.connect')
-        def test_generate_reply_rpc_error_4(self, mock_dev, mock_tostring, mock_err, mock_rpc, mock_write_warn):
-            from jnpr.junos.exception import RpcError
-            mock_rpc.side_effect = RpcError
-            par = Parser()
-            test_file = os.path.join(os.path.dirname(__file__),
-                                     'configs', 'bogus_testfile_4.yml')
-            test_file = open(test_file, 'r')
-            test_file = yaml.load(test_file)
-            dev = Device(host='10.221.136.250', user='abc', passwd='xyz')
-            dev.open()
-            par.generate_reply(test_file, dev, 'mock.xml', self.hostname, self.db)
-            mock_err.assert_called()
-            mock_write_warn.assert_called()
+    @patch('jnpr.jsnapy.snap.Parser._write_warning')
+    @patch('jnpr.junos.rpcmeta._RpcMetaExec.__getattr__')
+    @patch('logging.Logger.error')
+    @patch('lxml.etree.tostring')
+    @patch('ncclient.manager.connect')
+    def test_generate_reply_rpc_error_4(self, mock_dev, mock_tostring, mock_err, mock_rpc, mock_write_warn):
+        from jnpr.junos.exception import RpcError
+        mock_rpc.side_effect = RpcError
+        par = Parser()
+        test_file = os.path.join(os.path.dirname(__file__),
+                                 'configs', 'bogus_testfile_4.yml')
+        test_file = open(test_file, 'r')
+        test_file = yaml.load(test_file)
+        dev = Device(host='10.221.136.250', user='abc', passwd='xyz')
+        dev.open()
+        par.generate_reply(test_file, dev, 'mock.xml', self.hostname, self.db)
+        mock_err.assert_called()
+        mock_write_warn.assert_called()
 
-        @patch('jnpr.jsnapy.snap.Parser._write_warning')
-        @patch('jnpr.junos.rpcmeta._RpcMetaExec.__getattr__')
-        @patch('logging.Logger.error')
-        @patch('lxml.etree.tostring')
-        @patch('ncclient.manager.connect')
-        def test_generate_reply_rpc_error_5(self, mock_dev, mock_tostring, mock_err, mock_rpc, mock_write_warn):
-            from jnpr.junos.exception import RpcError
-            mock_rpc.side_effect = RpcError
-            par = Parser()
-            test_file = os.path.join(os.path.dirname(__file__),
-                                     'configs', 'bogus_testfile_5.yml')
-            test_file = open(test_file, 'r')
-            test_file = yaml.load(test_file)
-            dev = Device(host='10.221.136.250', user='abc', passwd='xyz')
-            dev.open()
-            par.generate_reply(test_file, dev, 'mock.xml', self.hostname, self.db)
-            mock_err.assert_called()
-            mock_write_warn.assert_called()
+    @patch('jnpr.jsnapy.snap.Parser._write_warning')
+    @patch('jnpr.junos.rpcmeta._RpcMetaExec.__getattr__')
+    @patch('logging.Logger.error')
+    @patch('lxml.etree.tostring')
+    @patch('ncclient.manager.connect')
+    def test_generate_reply_rpc_error_5(self, mock_dev, mock_tostring, mock_err, mock_rpc, mock_write_warn):
+        from jnpr.junos.exception import RpcError
+        mock_rpc.side_effect = RpcError
+        par = Parser()
+        test_file = os.path.join(os.path.dirname(__file__),
+                                 'configs', 'bogus_testfile_5.yml')
+        test_file = open(test_file, 'r')
+        test_file = yaml.load(test_file)
+        dev = Device(host='10.221.136.250', user='abc', passwd='xyz')
+        dev.open()
+        par.generate_reply(test_file, dev, 'mock.xml', self.hostname, self.db)
+        mock_err.assert_called()
+        mock_write_warn.assert_called()
 
-        @patch('logging.Logger.info')
-        def test_write_file_rpc_reply_true(self, mock_log):
-            par = Parser()
-            par._write_file(True, 'xml', 'mock.xml')
-            c = mock_log.call_args_list[0]
-            self.assertNotEqual(
-                c[0][0].find("Output of requested Command/RPC is empty"), -1)
+    @patch('logging.Logger.info')
+    def test_write_file_rpc_reply_true(self, mock_log):
+        par = Parser()
+        par._write_file(True, 'xml', 'mock.xml')
+        c = mock_log.call_args_list[0]
+        self.assertNotEqual(
+            c[0][0].find("Output of requested Command/RPC is empty"), -1)
 
-        @patch('jnpr.jsnapy.snap.Parser.store_in_sqlite')
-        def test_write_warning(self, mock_store_data):
-            self.db['store_in_sqlite'] = True
-            par = Parser()
-            par._write_warning("mock_reply", self.db, 'mock.xml', self.hostname
-                               , 'mock_cmd', 'text', 'mock_output')
-            mock_store_data.assert_called()
+    @patch('jnpr.jsnapy.snap.Parser.store_in_sqlite')
+    def test_write_warning(self, mock_store_data):
+        self.db['store_in_sqlite'] = True
+        par = Parser()
+        par._write_warning("mock_reply", self.db, 'mock.xml', self.hostname
+                           , 'mock_cmd', 'text', 'mock_output')
+        mock_store_data.assert_called()
+
+
 
 # with nested(
 #         patch('jnpr.jsnapy.snap.logging.getLogger'),


### PR DESCRIPTION
This is a revised Fix for issue #187 which covers the following testcases:

```
test_show_interfaces:
  - iterate:
      xpath: physical-interface
      id: name
      tests:
         - no-diff: oper-status
           info: "Passed"
           err: "Failed"
  - kwargs:
      interface-name: lo0
  - rpc: get-interface-information

```

```
test_show_interfaces:
  - iterate:
      xpath: physical-interface
      id: name
      tests:
         - no-diff: oper-status
           info: "Passed"
           err: "Failed"
  - rpc: get-interface-information

```
```
test_show_interfaces:
  - rpc: get-interface-information
  - iterate:
      xpath: physical-interface
      id: name
      tests:
         - no-diff: oper-status
           info: "Passed"
           err: "Failed"
  - kwargs:
      interface-name: lo0
  
```

Basically in any order possible.