### PR TITLE
Adding Testcase Description field

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 [![PyPi Version](https://img.shields.io/pypi/v/jsnapy.svg)](https://pypi.python.org/pypi/jsnapy/)
 [![Coverage Status](https://travis-ci.org/Juniper/jsnapy.svg?branch=master)](https://travis-ci.org/Juniper/jsnapy)
 [![Coverage Status](https://coveralls.io/repos/github/Juniper/jsnapy/badge.svg?branch=master)](https://coveralls.io/github/Juniper/jsnapy?branch=master)
-[![PyPi Version](https://img.shields.io/pypi/v/jsnapy.svg)](https://pypi.python.org/pypi/jsnapy/) [![Coverage Status](https://travis-ci.org/Juniper/jsnapy.svg?branch=master)](https://travis-ci.org/Juniper/jsnapy)
 
 # JSNAPy
 Python version of Junos Snapshot Administrator

--- a/tests/unit/configs/conditional_op_pass.yml
+++ b/tests/unit/configs/conditional_op_pass.yml
@@ -17,5 +17,6 @@ test_command_version:
                   - contains: //bgp-options, LogUpDown
               - is-equal: local-address, unspecified
   - command: show bgp neighbor
+  - description: "This Test is for bgp flap count"
             
               


### PR DESCRIPTION
### What issues does this PR fix or reference?
Fix #309 
### Previous Behavior
No description Field in testcase definition file

### New Behavior
Now the testcases can be defined in the following manner.
```
test_show_interfaces:
  - rpc: get-interface-information
  - kwargs:
      interface-name: lo0
  - iterate:
      xpath: physical-interface
      id: name
      tests:
         - no-diff: oper-status
           info: "Passed"
           err: "Failed"

test_show_interfaces_1:
  - rpc: get-interface-information
  - kwargs:
      interface-name: lo0
  - iterate:
      xpath: physical-interface
      id: name
      tests:
         - no-diff: oper-status
           info: "Passed"
           err: "Failed"
  - description: "This Test is for comparing the diff between the oper-status node in rpc get-interface-information."
```
**************************** Device: 10.204.49.97 ****************************
Tests Included: test_show_interfaces_1 
Description: This Test is for comparing the diff between the oper-status node in rpc get-interface-information. 
*************************RPC is get-interface-information*************************
Failed
FAIL | All "oper-status" is not same in pre and post snapshot [ 0 matched / 1 failed ]
Tests Included: test_show_interfaces 
*************************RPC is get-interface-information*************************
Failed
FAIL | All "oper-status" is not same in pre and post snapshot [ 0 matched / 1 failed ]
------------------------------- Final Result!! -------------------------------
test_show_interfaces_1 : Failed
test_show_interfaces : Failed
Total No of tests passed: 0
Total No of tests failed: 2 
Overall Tests failed!!! 

### Tests written?

Yes, will be given in next commit
