### PR TITLE
Fix yaml load error

### DIFF
--- a/lib/jnpr/jsnapy/check.py
+++ b/lib/jnpr/jsnapy/check.py
@@ -603,7 +603,7 @@ class Comparator:
                         tfile)
                 if os.path.isfile(tfile):
                     test_file = open(tfile, 'r')
-                    tests_files.append(yaml.load(test_file))
+                    tests_files.append(yaml.load(test_file, Loader=yaml.FullLoader))
                 else:
                     self.logger_check.error(
                         colorama.Fore.RED +

--- a/lib/jnpr/jsnapy/jsnapy.py
+++ b/lib/jnpr/jsnapy/jsnapy.py
@@ -327,11 +327,11 @@ class SnapAdmin:
         if conf_file is not None:
             if os.path.isfile(conf_file):
                 config_file = open(conf_file, 'r')
-                self.main_file = yaml.load(config_file)
+                self.main_file = yaml.load(config_file, Loader=yaml.FullLoader)
             elif os.path.isfile(os.path.join(get_path('DEFAULT', 'config_file_path'), conf_file)):
                 fpath = get_path('DEFAULT', 'config_file_path')
                 config_file = open(os.path.join(fpath, conf_file), 'r')
-                self.main_file = yaml.load(config_file)
+                self.main_file = yaml.load(config_file, Loader=yaml.FullLoader)
             else:
                 self.logger.error(
                     colorama.Fore.RED +
@@ -388,7 +388,7 @@ class SnapAdmin:
                     tfile)
             if os.path.isfile(tfile):
                 test_file = open(tfile, 'r')
-                test_files.append(yaml.load(test_file))
+                test_files.append(yaml.load(test_file, Loader=yaml.FullLoader))
             else:
                 self.logger.error(
                     colorama.Fore.RED +
@@ -484,7 +484,7 @@ class SnapAdmin:
                                         'test_file_path')),
                                     devices_file_name)
                     login_file = open(lfile, 'r')
-                    dev_file = yaml.load(login_file)
+                    dev_file = yaml.load(login_file, Loader=yaml.FullLoader)
                     gp = first_entry.get('group', 'all')
 
                     dgroup = [i.strip().lower() for i in gp.split(',')]
@@ -604,7 +604,7 @@ class SnapAdmin:
                         if os.path.isfile(mail_file_path) is False else mail_file_path
                 if os.path.isfile(mfile):
                     mail_file = open(mfile, 'r')
-                    mail_file = yaml.load(mail_file)
+                    mail_file = yaml.load(mail_file, Loader=yaml.FullLoader)
                     if "passwd" not in mail_file:
                         passwd = getpass.getpass(
                             "Please enter ur email password ")
@@ -756,7 +756,7 @@ class SnapAdmin:
                                 'test_file_path')),
                             devices_file_name)
             login_file = open(lfile, 'r')
-            dev_file = yaml.load(login_file)
+            dev_file = yaml.load(login_file, Loader=yaml.FullLoader)
             gp = first_entry.get('group', 'all')
 
             dgroup = [i.strip().lower() for i in gp.split(',')]
@@ -834,9 +834,9 @@ class SnapAdmin:
         val =[]
         if os.path.isfile(config_data):
             data = open(config_data, 'r')
-            config_data = yaml.load(data)
+            config_data = yaml.load(data, Loader=yaml.FullLoader)
         elif isinstance(config_data, str):
-            config_data = yaml.load(config_data)
+            config_data = yaml.load(config_data, Loader=yaml.FullLoader)
         else:
             self.logger.info(
                 colorama.Fore.RED +
@@ -908,9 +908,9 @@ class SnapAdmin:
             pass
         elif os.path.isfile(config_data):
             data = open(config_data, 'r')
-            config_data = yaml.load(data)
+            config_data = yaml.load(data, Loader=yaml.FullLoader)
         elif isinstance(config_data, str):
-            config_data = yaml.load(config_data)
+            config_data = yaml.load(config_data, Loader=yaml.FullLoader)
         else:
             self.logger.info(
                 colorama.Fore.RED +

--- a/lib/jnpr/jsnapy/setup_logging.py
+++ b/lib/jnpr/jsnapy/setup_logging.py
@@ -22,7 +22,7 @@ def setup_logging(
         path = value
     if os.path.exists(path):
         with open(path, 'rt') as f:
-            config = yaml.load(f.read())
+            config = yaml.load(f.read(), Loader=yaml.FullLoader)
         logging.config.dictConfig(config)
     else:
         logging.basicConfig(level=default_level)

--- a/tests/unit/test_check.py
+++ b/tests/unit/test_check.py
@@ -30,7 +30,7 @@ class TestCheck(unittest.TestCase):
         conf_file = os.path.join(os.path.dirname(__file__),
                                  'configs', 'main_incorrect_1.yml')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         with patch('logging.Logger.error') as mock_error:
             comp.generate_test_files(
                 main_file,
@@ -54,7 +54,7 @@ class TestCheck(unittest.TestCase):
         conf_file = os.path.join(os.path.dirname(__file__),
                                  'configs', 'main_incorrect_2.yml')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         filename = os.path.join('/etc', 'jsnapy', 'testfiles', "dummy.yml")
         with patch('logging.Logger.error') as mock_error:
             comp.generate_test_files(
@@ -78,7 +78,7 @@ class TestCheck(unittest.TestCase):
         conf_file = os.path.join(os.path.dirname(__file__),
                                  'configs', 'main_incorrect_3.yml')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         with patch('logging.Logger.error') as mock_log:
             comp.generate_test_files(
                 main_file,
@@ -105,7 +105,7 @@ class TestCheck(unittest.TestCase):
         conf_file = os.path.join(os.path.dirname(__file__),
                                  'configs', 'main_incorrect_4.yml')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         self.db['check_from_sqlite'] = True
         with patch('logging.Logger.error') as mock_log:
             try:
@@ -132,7 +132,7 @@ class TestCheck(unittest.TestCase):
         conf_file = os.path.join(os.path.dirname(__file__),
                                  'configs', 'main_incorrect_4.yml')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         with patch('logging.Logger.error') as mock_log:
             comp.generate_test_files(
@@ -158,7 +158,7 @@ class TestCheck(unittest.TestCase):
                                  'configs', 'main_empty_test.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         with patch('jnpr.jsnapy.check.XmlComparator.xml_compare') as mock_compare:
             comp.generate_test_files(
                 main_file,
@@ -181,7 +181,7 @@ class TestCheck(unittest.TestCase):
         conf_file = os.path.join(os.path.dirname(__file__),
                                  'configs', 'main_empty_test.yml')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         with patch('jnpr.jsnapy.check.diff') as mock_compare:
             comp.generate_test_files(
                 main_file,
@@ -204,7 +204,7 @@ class TestCheck(unittest.TestCase):
                                  'configs', 'main_conditional_op_fail.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -226,7 +226,7 @@ class TestCheck(unittest.TestCase):
                                  'configs', 'main_conditional_op_error_1.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -247,7 +247,7 @@ class TestCheck(unittest.TestCase):
                                  'configs', 'main_conditional_op_error_2.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -269,7 +269,7 @@ class TestCheck(unittest.TestCase):
                                  'configs', 'main_conditional_op_error_3.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -291,7 +291,7 @@ class TestCheck(unittest.TestCase):
                                  'configs', 'main_conditional_op_error_4.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -312,7 +312,7 @@ class TestCheck(unittest.TestCase):
                                  'configs', 'main_conditional_op_pass.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -339,7 +339,7 @@ class TestCheck(unittest.TestCase):
         conf_file = os.path.join(os.path.dirname(__file__),
                                  'configs', 'main_rpc_test.yml')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         self.db['check_from_sqlite'] = True
         comp = Comparator()
         comp.generate_test_files(
@@ -366,7 +366,7 @@ class TestCheck(unittest.TestCase):
         conf_file = os.path.join(os.path.dirname(__file__),
                                  'configs', 'main_rpc_test.yml')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         self.db['check_from_sqlite'] = True
         self.db['first_snap_id'] = 0
         self.db['second_snap_id'] = 1
@@ -440,7 +440,7 @@ class TestCheck(unittest.TestCase):
                                  'configs', 'main_xpath_functions.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,

--- a/tests/unit/test_comparison_op.py
+++ b/tests/unit/test_comparison_op.py
@@ -29,7 +29,7 @@ class TestComparisonOperator(unittest.TestCase):
                                  'configs', 'main_list-not-less.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -51,7 +51,7 @@ class TestComparisonOperator(unittest.TestCase):
                                  'configs', 'main_list-not-less_ignore-null_fail.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -73,7 +73,7 @@ class TestComparisonOperator(unittest.TestCase):
                                  'configs', 'main_list-not-less_ignore-null_fail_1.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -95,7 +95,7 @@ class TestComparisonOperator(unittest.TestCase):
                                  'configs', 'main_list-not-less_ignore-null_skip.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -117,7 +117,7 @@ class TestComparisonOperator(unittest.TestCase):
                                  'configs', 'main_list-not-less_ignore-null_skip_1.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -139,7 +139,7 @@ class TestComparisonOperator(unittest.TestCase):
                                  'configs', 'main_list-not-less_ignore-null_id_skip.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -161,7 +161,7 @@ class TestComparisonOperator(unittest.TestCase):
                                  'configs', 'main_list-not-less.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -183,7 +183,7 @@ class TestComparisonOperator(unittest.TestCase):
                                  'configs', 'main_list-not-more.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -207,7 +207,7 @@ class TestComparisonOperator(unittest.TestCase):
                                  'configs', 'main_list-not-more.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -229,7 +229,7 @@ class TestComparisonOperator(unittest.TestCase):
                                  'configs', 'main_list-not-more_ignore-null_fail.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -251,7 +251,7 @@ class TestComparisonOperator(unittest.TestCase):
                                  'configs', 'main_list-not-more_ignore-null_fail_1.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -273,7 +273,7 @@ class TestComparisonOperator(unittest.TestCase):
                                  'configs', 'main_list-not-more_ignore-null_skip.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -295,7 +295,7 @@ class TestComparisonOperator(unittest.TestCase):
                                  'configs', 'main_list-not-more_ignore-null_skip_1.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -317,7 +317,7 @@ class TestComparisonOperator(unittest.TestCase):
                                  'configs', 'main_list-not-more_ignore-null_id_skip.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -339,7 +339,7 @@ class TestComparisonOperator(unittest.TestCase):
                                  'configs', 'main_delta.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -361,7 +361,7 @@ class TestComparisonOperator(unittest.TestCase):
                                  'configs', 'main_delta_ignore-null_fail.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -382,7 +382,7 @@ class TestComparisonOperator(unittest.TestCase):
                                  'configs', 'main_delta_ignore-null_fail_1.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -404,7 +404,7 @@ class TestComparisonOperator(unittest.TestCase):
                                  'configs', 'main_delta_ignore-null_skip.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -426,7 +426,7 @@ class TestComparisonOperator(unittest.TestCase):
                                  'configs', 'main_delta_ignore-null_skip_1.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -448,7 +448,7 @@ class TestComparisonOperator(unittest.TestCase):
                                  'configs', 'main_delta_ignore-null_id_skip.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -470,7 +470,7 @@ class TestComparisonOperator(unittest.TestCase):
                                  'configs', 'main_delta.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -492,7 +492,7 @@ class TestComparisonOperator(unittest.TestCase):
                                  'configs', 'main_no-diff.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -514,7 +514,7 @@ class TestComparisonOperator(unittest.TestCase):
                                  'configs', 'main_dot-dot.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -538,7 +538,7 @@ class TestComparisonOperator(unittest.TestCase):
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         mock_sqlite_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -565,7 +565,7 @@ class TestComparisonOperator(unittest.TestCase):
         sqlite_mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
 
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -587,7 +587,7 @@ class TestComparisonOperator(unittest.TestCase):
                                  'configs', 'main_no-diff_ignore-null_id_skip.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,

--- a/tests/unit/test_jsnapy.py
+++ b/tests/unit/test_jsnapy.py
@@ -39,7 +39,7 @@ class TestSnapAdmin(unittest.TestCase):
         conf_file = os.path.join(os.path.dirname(__file__),
                                  'configs', 'main.yml')
         config_file = open(conf_file, 'r')
-        js.main_file = yaml.load(config_file)
+        js.main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         js.generate_rpc_reply(
             None,
             "snap_mock",
@@ -60,7 +60,7 @@ class TestSnapAdmin(unittest.TestCase):
         conf_file = os.path.join(os.path.dirname(__file__),
                                  'configs', 'main_6.yml')
         config_file = open(conf_file, 'r')
-        js.main_file = yaml.load(config_file)
+        js.main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         js.login("snap_1")
         expected_calls_made = [call('1.1.1.1', 'abc', 'xyz', 'snap_1'),
                                call('1.1.1.15', 'abc', 'xyz', 'snap_1'),
@@ -87,7 +87,7 @@ class TestSnapAdmin(unittest.TestCase):
         conf_file = os.path.join(os.path.dirname(__file__),
                                  'configs', 'main1.yml')
         config_file = open(conf_file, 'r')
-        js.main_file = yaml.load(config_file)
+        js.main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         js.login("snap_1")
         hosts = ['1.1.1.3', '1.1.1.4', '1.1.1.5']
         self.assertEqual(js.host_list, hosts)
@@ -132,7 +132,7 @@ class TestSnapAdmin(unittest.TestCase):
         conf_file = os.path.join(os.path.dirname(__file__),
                                  'configs', 'main_false_keyError.yml')
         config_file = open(conf_file, 'r')
-        js.main_file = yaml.load(config_file)
+        js.main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         js.login("snap_1")
         self.assertTrue(mock_log.called)
         mock_log.assert_called_with("\x1b[31m\nERROR occurred !! Hostname not given properly 'hosts'",
@@ -144,7 +144,7 @@ class TestSnapAdmin(unittest.TestCase):
         conf_file = os.path.join(os.path.dirname(__file__),
                                  'configs', 'main_false_keyError.yml')
         config_file = open(conf_file, 'r')
-        js.main_file = yaml.load(config_file)
+        js.main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         js.main_file = None
         js.login("snap_1")
         self.assertTrue(mock_log.called)
@@ -156,7 +156,7 @@ class TestSnapAdmin(unittest.TestCase):
         conf_file = os.path.join(os.path.dirname(__file__),
                                  'configs', 'main_false_keyError_device.yml')
         config_file = open(conf_file, 'r')
-        js.main_file = yaml.load(config_file)
+        js.main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         js.login("snap_1")
         self.assertTrue(mock_log.called)
         mock_log.assert_called_with("\x1b[31mERROR!! KeyError 'device' key not found", extra={'hostname': None})
@@ -165,7 +165,7 @@ class TestSnapAdmin(unittest.TestCase):
     def test_multiple_hostname_1(self, mock_connect):
         js = SnapAdmin()
         config_file = open('main1.yml', 'r')
-        js.main_file = yaml.load(config_file)
+        js.main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         js.login("snap_1")
         hosts = ['1.1.1.3', '1.1.1.4', '1.1.1.5']
         self.assertEqual(js.host_list, hosts)
@@ -196,7 +196,7 @@ class TestSnapAdmin(unittest.TestCase):
         js.args.file = os.path.join(os.path.dirname(__file__),
                                     'configs', 'main_1.yml')
         config_file = open(js.args.file, 'r')
-        config_data = yaml.load(config_file)
+        config_data = yaml.load(config_file, Loader=yaml.FullLoader)
         js.args.check = True
         js.args.pre_snapfile = "mock_snap1"
         js.args.post_snapfile = "mock_snap2"
@@ -228,7 +228,7 @@ class TestSnapAdmin(unittest.TestCase):
         js.args.file = os.path.join(os.path.dirname(__file__),
                                     'configs', 'main_1.yml')
         config_file = open(js.args.file, 'r')
-        config_data = yaml.load(config_file)
+        config_data = yaml.load(config_file, Loader=yaml.FullLoader)
         js.args.pre_snapfile = "mock_snap"
         js.get_hosts()
         self.assertTrue(mock_snap.called)
@@ -253,7 +253,7 @@ class TestSnapAdmin(unittest.TestCase):
         js.args.file = os.path.join(os.path.dirname(__file__),
                                     'configs', 'main_1.yml')
         config_file = open(js.args.file, 'r')
-        config_data = yaml.load(config_file)
+        config_data = yaml.load(config_file, Loader=yaml.FullLoader)
         js.args.pre_snapfile = "mock_snap"
         js.get_hosts()
         self.assertFalse(mock_dev.called)
@@ -278,7 +278,7 @@ class TestSnapAdmin(unittest.TestCase):
         js.args.file = os.path.join(os.path.dirname(__file__),
                                     'configs', 'main_local_snapcheck.yml')
         config_file = open(js.args.file, 'r')
-        config_data = yaml.load(config_file)
+        config_data = yaml.load(config_file, Loader=yaml.FullLoader)
         js.args.pre_snapfile = "mock_snap"
         js.get_hosts()
         self.assertTrue(js.args.local)
@@ -306,7 +306,7 @@ class TestSnapAdmin(unittest.TestCase):
         js.args.file = os.path.join(os.path.dirname(__file__),
                                     'configs', 'main_1.yml')
         config_file = open(js.args.file, 'r')
-        config_data = yaml.load(config_file)
+        config_data = yaml.load(config_file, Loader=yaml.FullLoader)
         js.args.diff = True
         js.args.pre_snapfile = "mock_snap1"
         js.args.post_snapfile = "mock_snap2"
@@ -481,7 +481,7 @@ class TestSnapAdmin(unittest.TestCase):
         js.args.file = os.path.join(os.path.dirname(__file__),
                                     'configs', 'main_1.yml')
         config_file = open(js.args.file, 'r')
-        config_data = yaml.load(config_file)
+        config_data = yaml.load(config_file, Loader=yaml.FullLoader)
         with patch(builtin_string + 'input', return_value='abc'):
             js.connect('1.1.1.1', None, 'xyz', 'snap_1', config_data)
             # username='abc'
@@ -498,7 +498,7 @@ class TestSnapAdmin(unittest.TestCase):
         js.args.file = os.path.join(os.path.dirname(__file__),
                                     'configs', 'main_1.yml')
         config_file = open(js.args.file, 'r')
-        config_data = yaml.load(config_file)
+        config_data = yaml.load(config_file, Loader=yaml.FullLoader)
         js.connect('1.1.1.1', 'abc', 'xyz', 'snap_1', config_data)
         mock_log.assert_called()
         mock_dev.assert_called_with(host='1.1.1.1', user='abc', passwd='xyz', gather_facts=False)
@@ -514,7 +514,7 @@ class TestSnapAdmin(unittest.TestCase):
             js.args.file = os.path.join(os.path.dirname(__file__),
                                         'configs', 'main_1.yml')
             config_file = open(js.args.file, 'r')
-            config_data = yaml.load(config_file)
+            config_data = yaml.load(config_file, Loader=yaml.FullLoader)
             mock_dev.side_effect = Exception()
             js.connect('1.1.1.1', 'abc', None, 'snap_1', config_data)
 
@@ -524,7 +524,7 @@ class TestSnapAdmin(unittest.TestCase):
         js = SnapAdmin()
         js.args.file = os.path.join(os.path.dirname(__file__), 'configs', 'main1.yml')
         config_file = open(js.args.file, 'r')
-        config_data = yaml.load(config_file)
+        config_data = yaml.load(config_file, Loader=yaml.FullLoader)
         hosts = config_data.get('hosts')
         js.multiple_device_details(hosts, config_data, 'mock_pre', None, 'mock_post')
         hosts_required = ['1.1.1.3', '1.1.1.4', '1.1.1.5']
@@ -541,7 +541,7 @@ class TestSnapAdmin(unittest.TestCase):
         js = SnapAdmin()
         js.args.file = os.path.join(os.path.dirname(__file__), 'configs', 'main1.yml')
         config_file = open(js.args.file, 'r')
-        config_data = yaml.load(config_file)
+        config_data = yaml.load(config_file, Loader=yaml.FullLoader)
         hosts = config_data.get('hosts')
         js.multiple_device_details(hosts, config_data, 'mock_pre', None, 'mock_post')
         hosts_required = ['1.1.1.3', '1.1.1.4', '1.1.1.5']
@@ -552,7 +552,7 @@ class TestSnapAdmin(unittest.TestCase):
         js = SnapAdmin()
         js.args.file = os.path.join(os.path.dirname(__file__), 'configs', 'main_6.yml')
         config_file = open(js.args.file, 'r')
-        config_data = yaml.load(config_file)
+        config_data = yaml.load(config_file, Loader=yaml.FullLoader)
         hosts = config_data.get('hosts')
         js.multiple_device_details(hosts, config_data, 'mock_pre', None, 'mock_post')
         hosts_required = ['1.1.1.1', '1.1.1.15', '1.1.1.16']
@@ -563,7 +563,7 @@ class TestSnapAdmin(unittest.TestCase):
         js = SnapAdmin()
         js.args.file = os.path.join(os.path.dirname(__file__), 'configs', 'main_false_keyError_device.yml')
         config_file = open(js.args.file, 'r')
-        config_data = yaml.load(config_file)
+        config_data = yaml.load(config_file, Loader=yaml.FullLoader)
         hosts = config_data.get('hosts')
         js.multiple_device_details(hosts, config_data, 'mock_pre', None, 'mock_post')
         mock_log.assert_called_with("\x1b[31mERROR!! KeyError 'device' key not found", extra={'hostname': None})
@@ -573,7 +573,7 @@ class TestSnapAdmin(unittest.TestCase):
         js = SnapAdmin()
         js.args.file = os.path.join(os.path.dirname(__file__), 'configs', 'main_6.yml')
         config_file = open(js.args.file, 'r')
-        config_data = yaml.load(config_file)
+        config_data = yaml.load(config_file, Loader=yaml.FullLoader)
         hosts = config_data.get('hosts')
         js.multiple_device_details(hosts, config_data, 'mock_pre', 'snap', 'mock_post')
         mock_dev_connect.assert_called()
@@ -583,7 +583,7 @@ class TestSnapAdmin(unittest.TestCase):
         js = SnapAdmin()
         js.args.file = os.path.join(os.path.dirname(__file__), 'configs', 'main_6.yml')
         config_file = open(js.args.file, 'r')
-        config_data = yaml.load(config_file)
+        config_data = yaml.load(config_file, Loader=yaml.FullLoader)
         hosts = config_data.get('hosts')
         js.multiple_device_details(hosts, config_data, 'mock_pre', 'snapcheck', 'mock_post')
         mock_dev_connect.assert_called()
@@ -720,7 +720,7 @@ class TestSnapAdmin(unittest.TestCase):
         js = SnapAdmin()
         js.args.file = os.path.join(os.path.dirname(__file__), 'configs', 'main_local.yml')
         data = open(js.args.file, 'r')
-        config_data = yaml.load(data)  # providing the data as dictionary
+        config_data = yaml.load(data)  # providing the data as dictionary, Loader=yaml.FullLoader
         js.extract_dev_data(dev, config_data, 'mock_pre', 'snapcheck', 'mock_post', local=False)
         mock_get_test.assert_called()
 
@@ -824,7 +824,7 @@ class TestSnapAdmin(unittest.TestCase):
             js.db['store_in_sqlite'] = True
             js.args.file = os.path.join(os.path.dirname(__file__), 'configs', 'main.yml')
             config_file = open(js.args.file, 'r')
-            config_data = yaml.load(config_file)
+            config_data = yaml.load(config_file, Loader=yaml.FullLoader)
             del (config_data['sqlite'][0]['database_name'])  # either we could have a config file with no db name
             del (config_data['sqlite'][0]['store_in_sqlite'])
             del (config_data['sqlite'][0]['check_from_sqlite'])
@@ -836,7 +836,7 @@ class TestSnapAdmin(unittest.TestCase):
             js.db['store_in_sqlite'] = True
             js.args.file = os.path.join(os.path.dirname(__file__), 'configs', 'main.yml')
             config_file = open(js.args.file, 'r')
-            config_data = yaml.load(config_file)
+            config_data = yaml.load(config_file, Loader=yaml.FullLoader)
             del (config_data['sqlite'][0]['store_in_sqlite'])
             del (config_data['sqlite'][0]['check_from_sqlite'])
             config_data['sqlite'][0]['compare'] = 0
@@ -848,7 +848,7 @@ class TestSnapAdmin(unittest.TestCase):
             js.db['store_in_sqlite'] = True
             js.args.file = os.path.join(os.path.dirname(__file__), 'configs', 'main.yml')
             config_file = open(js.args.file, 'r')
-            config_data = yaml.load(config_file)
+            config_data = yaml.load(config_file, Loader=yaml.FullLoader)
             del (config_data['sqlite'][0]['store_in_sqlite'])
             del (config_data['sqlite'][0]['check_from_sqlite'])
             config_data['sqlite'][0]['compare'] = 'ab'
@@ -860,7 +860,7 @@ class TestSnapAdmin(unittest.TestCase):
             js.db['store_in_sqlite'] = True
             js.args.file = os.path.join(os.path.dirname(__file__), 'configs', 'main.yml')
             config_file = open(js.args.file, 'r')
-            config_data = yaml.load(config_file)
+            config_data = yaml.load(config_file, Loader=yaml.FullLoader)
             del (config_data['sqlite'][0]['store_in_sqlite'])
             del (config_data['sqlite'][0]['check_from_sqlite'])
             config_data['sqlite'][0]['compare'] = '0,1,2'
@@ -872,7 +872,7 @@ class TestSnapAdmin(unittest.TestCase):
             js.db['store_in_sqlite'] = True
             js.args.file = os.path.join(os.path.dirname(__file__), 'configs', 'main.yml')
             config_file = open(js.args.file, 'r')
-            config_data = yaml.load(config_file)
+            config_data = yaml.load(config_file, Loader=yaml.FullLoader)
             del (config_data['sqlite'][0]['store_in_sqlite'])
             del (config_data['sqlite'][0]['check_from_sqlite'])
             config_data['sqlite'][0]['compare'] = '0'
@@ -1283,7 +1283,7 @@ class TestSnapAdmin(unittest.TestCase):
         conf_file = os.path.join(os.path.dirname(__file__),
                                  'configs', 'main_with_port.yml')
         config_file = open(conf_file, 'r')
-        js.main_file = yaml.load(config_file)
+        js.main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         js.login("snap_1")
         hosts = ['1.1.1.1']
         self.assertEqual(js.host_list, hosts)
@@ -1329,7 +1329,7 @@ class TestSnapAdmin(unittest.TestCase):
         conf_file = os.path.join(os.path.dirname(__file__),
                                  'configs', 'main2_with_port.yml')
         config_file = open(conf_file, 'r')
-        js.main_file = yaml.load(config_file)
+        js.main_file = yaml.load(config_file, Loader=yaml.FullLoader)
 
         hosts = ['1.1.1.3', '1.1.1.4', '1.1.1.5']
         expected_calls_made = [call('1.1.1.3', 'abc', 'def', 'snap_1', port=100),

--- a/tests/unit/test_notify.py
+++ b/tests/unit/test_notify.py
@@ -30,7 +30,7 @@ class TestCheck(unittest.TestCase):
         res.result = 'Passed'
         mfile = os.path.join(os.path.dirname(__file__), 'configs', 'mail.yml')
         mail_file = open(mfile, 'r')
-        mail_file = yaml.load(mail_file)   #smtplib.SMTP#connectsocket.getfqdn
+        mail_file = yaml.load(mail_file)   #smtplib.SMTP#connectsocket.getfqdn, Loader=yaml.FullLoader
         passwd = mail_file['passwd']
         notf = Notification()
         notf.notify(mail_file, self.hostname, passwd, res)
@@ -53,7 +53,7 @@ class TestCheck(unittest.TestCase):
         res.result = 'Passed'
         mfile = os.path.join(os.path.dirname(__file__), 'configs', 'mail.yml')
         mail_file = open(mfile, 'r')
-        mail_file = yaml.load(mail_file)   #smtplib.SMTP#connectsocket.getfqdn
+        mail_file = yaml.load(mail_file)   #smtplib.SMTP#connectsocket.getfqdn, Loader=yaml.FullLoader
         passwd = mail_file['passwd']
         notf = Notification()
         notf.notify(mail_file, self.hostname, passwd, res)

--- a/tests/unit/test_numeric_op.py
+++ b/tests/unit/test_numeric_op.py
@@ -27,7 +27,7 @@ class TestNumericOperators(unittest.TestCase):
                                  'configs', 'main_in-range.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -47,7 +47,7 @@ class TestNumericOperators(unittest.TestCase):
                                  'configs', 'main_in-range.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -67,7 +67,7 @@ class TestNumericOperators(unittest.TestCase):
                                  'configs', 'main_in-range_ignore-null_fail.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -87,7 +87,7 @@ class TestNumericOperators(unittest.TestCase):
                                  'configs', 'main_in-range_ignore-null_fail_1.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -107,7 +107,7 @@ class TestNumericOperators(unittest.TestCase):
                                  'configs', 'main_in-range_ignore-null_skip.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -127,7 +127,7 @@ class TestNumericOperators(unittest.TestCase):
                                  'configs', 'main_in-range_ignore-null_skip_1.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -147,7 +147,7 @@ class TestNumericOperators(unittest.TestCase):
                                  'configs', 'main_in-range_ignore-null_pass.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -167,7 +167,7 @@ class TestNumericOperators(unittest.TestCase):
                                  'configs', 'main_not-range.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -187,7 +187,7 @@ class TestNumericOperators(unittest.TestCase):
                                  'configs', 'main_not-range_ignore-null_fail.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -207,7 +207,7 @@ class TestNumericOperators(unittest.TestCase):
                                  'configs', 'main_not-range_ignore-null_fail_1.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -227,7 +227,7 @@ class TestNumericOperators(unittest.TestCase):
                                  'configs', 'main_not-range_ignore-null_skip.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -247,7 +247,7 @@ class TestNumericOperators(unittest.TestCase):
                                  'configs', 'main_not-range_ignore-null_skip_1.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -267,7 +267,7 @@ class TestNumericOperators(unittest.TestCase):
                                  'configs', 'main_not-range_ignore-null_pass.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -287,7 +287,7 @@ class TestNumericOperators(unittest.TestCase):
                                  'configs', 'main_not-range.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -307,7 +307,7 @@ class TestNumericOperators(unittest.TestCase):
                                  'configs', 'main_is-lt.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -327,7 +327,7 @@ class TestNumericOperators(unittest.TestCase):
                                  'configs', 'main_is-lt.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -347,7 +347,7 @@ class TestNumericOperators(unittest.TestCase):
                                  'configs', 'main_is-lt_ignore-null_fail.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -367,7 +367,7 @@ class TestNumericOperators(unittest.TestCase):
                                  'configs', 'main_is-lt_ignore-null_fail_1.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -387,7 +387,7 @@ class TestNumericOperators(unittest.TestCase):
                                  'configs', 'main_is-lt_ignore-null_skip.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -407,7 +407,7 @@ class TestNumericOperators(unittest.TestCase):
                                  'configs', 'main_is-lt_ignore-null_skip_1.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -427,7 +427,7 @@ class TestNumericOperators(unittest.TestCase):
                                  'configs', 'main_is-lt_ignore-null_pass.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -447,7 +447,7 @@ class TestNumericOperators(unittest.TestCase):
                                  'configs', 'main_is-gt.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -467,7 +467,7 @@ class TestNumericOperators(unittest.TestCase):
                                  'configs', 'main_is-gt_ignore-null_fail.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -487,7 +487,7 @@ class TestNumericOperators(unittest.TestCase):
                                  'configs', 'main_is-gt_ignore-null_fail_1.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -507,7 +507,7 @@ class TestNumericOperators(unittest.TestCase):
                                  'configs', 'main_is-gt_ignore-null_skip.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -527,7 +527,7 @@ class TestNumericOperators(unittest.TestCase):
                                  'configs', 'main_is-gt_ignore-null_skip_1.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -547,7 +547,7 @@ class TestNumericOperators(unittest.TestCase):
                                  'configs', 'main_is-gt_ignore-null_pass.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -567,7 +567,7 @@ class TestNumericOperators(unittest.TestCase):
                                  'configs', 'main_is-gt.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,

--- a/tests/unit/test_operator.py
+++ b/tests/unit/test_operator.py
@@ -192,7 +192,7 @@ class TestCheck(unittest.TestCase):
                                  'configs', 'main_list_not_more_no_node.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -214,7 +214,7 @@ class TestCheck(unittest.TestCase):
                                  'configs', 'main_list_not_more_node_missing.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -238,7 +238,7 @@ class TestCheck(unittest.TestCase):
                                      'configs', 'main_test_delta_index_error.yml')
             mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
             config_file = open(conf_file, 'r')
-            main_file = yaml.load(config_file)
+            main_file = yaml.load(config_file, Loader=yaml.FullLoader)
             oper = comp.generate_test_files(
                 main_file,
                 self.hostname,
@@ -259,7 +259,7 @@ class TestCheck(unittest.TestCase):
                                  'configs', 'main_delta_percentage.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -282,7 +282,7 @@ class TestCheck(unittest.TestCase):
                                      'configs', 'main_regex.yml')
             mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
             config_file = open(conf_file, 'r')
-            main_file = yaml.load(config_file)
+            main_file = yaml.load(config_file, Loader=yaml.FullLoader)
             oper = comp.generate_test_files(
                 main_file,
                 self.hostname,
@@ -303,7 +303,7 @@ class TestCheck(unittest.TestCase):
                                  'configs', 'main_regex_1.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -324,7 +324,7 @@ class TestCheck(unittest.TestCase):
                                  'configs', 'main_regex_2.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -345,7 +345,7 @@ class TestCheck(unittest.TestCase):
                                  'configs', 'main_regex_1.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -366,7 +366,7 @@ class TestCheck(unittest.TestCase):
                                  'configs', 'main_regex_1.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -387,7 +387,7 @@ class TestCheck(unittest.TestCase):
                                  'configs', 'main_xml_comparator.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,

--- a/tests/unit/test_snap.py
+++ b/tests/unit/test_snap.py
@@ -32,7 +32,7 @@ class TestSnap(unittest.TestCase):
         test_file = os.path.join(os.path.dirname(__file__),
                                  'configs', 'delta.yml')
         test_file = open(test_file, 'r')
-        test_file = yaml.load(test_file)
+        test_file = yaml.load(test_file, Loader=yaml.FullLoader)
         dev = jnpr.junos.device.Device(
             host="1.1.1.1",
             user="user",
@@ -62,7 +62,7 @@ class TestSnap(unittest.TestCase):
         conf_file = os.path.join(os.path.dirname(__file__),
                                  'configs', 'main.yml')
         config_file = open(conf_file, 'r')
-        js.main_file = yaml.load(config_file)
+        js.main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         dev = jnpr.junos.device.Device(
             host="1.1.1.1",
             user="user",
@@ -86,7 +86,7 @@ class TestSnap(unittest.TestCase):
         test_file = os.path.join(os.path.dirname(__file__),
                                  'configs', 'delta.yml')
         test_file = open(test_file, 'r')
-        test_file = yaml.load(test_file)
+        test_file = yaml.load(test_file, Loader=yaml.FullLoader)
         dev = jnpr.junos.device.Device(
             host="1.1.1.1",
             user="xyz",
@@ -107,7 +107,7 @@ class TestSnap(unittest.TestCase):
         test_file = os.path.join(os.path.dirname(__file__),
                                  'configs', 'delta_text.yml')
         test_file = open(test_file, 'r')
-        test_file = yaml.load(test_file)
+        test_file = yaml.load(test_file, Loader=yaml.FullLoader)
         dev = jnpr.junos.device.Device(
             host="1.1.1.1",
             user="xyz",
@@ -128,7 +128,7 @@ class TestSnap(unittest.TestCase):
         test_file = os.path.join(os.path.dirname(__file__),
                                  'configs', 'delta_error.yml')
         test_file = open(test_file, 'r')
-        test_file = yaml.load(test_file)
+        test_file = yaml.load(test_file, Loader=yaml.FullLoader)
         dev = jnpr.junos.device.Device(
             host="1.1.1.1",
             user="xyz",
@@ -150,7 +150,7 @@ class TestSnap(unittest.TestCase):
         test_file = os.path.join(os.path.dirname(__file__),
                                  'configs', 'test_rpc.yml')
         test_file = open(test_file, 'r')
-        test_file = yaml.load(test_file)
+        test_file = yaml.load(test_file, Loader=yaml.FullLoader)
         dev = jnpr.junos.device.Device(
             host="1.1.1.1",
             user="user_mock",
@@ -182,7 +182,7 @@ class TestSnap(unittest.TestCase):
         test_file = os.path.join(os.path.dirname(__file__),
                                  'configs', 'test_rpc.yml')
         test_file = open(test_file, 'r')
-        test_file = yaml.load(test_file)
+        test_file = yaml.load(test_file, Loader=yaml.FullLoader)
         dev = jnpr.junos.device.Device(
             host="1.1.1.1",
             user="xyz",
@@ -211,7 +211,7 @@ class TestSnap(unittest.TestCase):
         test_file = os.path.join(os.path.dirname(__file__),
                                  'configs', 'test_rpc_error.yml')
         test_file = open(test_file, 'r')
-        test_file = yaml.load(test_file)
+        test_file = yaml.load(test_file, Loader=yaml.FullLoader)
         dev = jnpr.junos.device.Device(
             host="1.1.1.1",
             user="user",
@@ -237,7 +237,7 @@ class TestSnap(unittest.TestCase):
         test_file = os.path.join(os.path.dirname(__file__),
                                  'configs', 'test_rpc_2.yml')
         test_file = open(test_file, 'r')
-        test_file = yaml.load(test_file)
+        test_file = yaml.load(test_file, Loader=yaml.FullLoader)
         dev = jnpr.junos.device.Device(
             host="1.1.1.1",
             user="xyz",
@@ -262,7 +262,7 @@ class TestSnap(unittest.TestCase):
         test_file = os.path.join(os.path.dirname(__file__),
                                  'configs', 'test_rpc_error_2.yml')
         test_file = open(test_file, 'r')
-        test_file = yaml.load(test_file)
+        test_file = yaml.load(test_file, Loader=yaml.FullLoader)
         dev = jnpr.junos.device.Device(
             host="1.1.1.1",
             user="xyz",
@@ -285,7 +285,7 @@ class TestSnap(unittest.TestCase):
         test_file = os.path.join(os.path.dirname(__file__),
                                  'configs', 'test_rpc_2_error.yml')
         test_file = open(test_file, 'r')
-        test_file = yaml.load(test_file)
+        test_file = yaml.load(test_file, Loader=yaml.FullLoader)
         dev = jnpr.junos.device.Device(
             host="1.1.1.1",
             user="xyz",
@@ -308,7 +308,7 @@ class TestSnap(unittest.TestCase):
         test_file = os.path.join(os.path.dirname(__file__),
                                  'configs', 'delta.yml')
         test_file = open(test_file, 'r')
-        test_file = yaml.load(test_file)
+        test_file = yaml.load(test_file, Loader=yaml.FullLoader)
         dev = jnpr.junos.device.Device(
             host="1.1.1.1",
             user="user",
@@ -337,7 +337,7 @@ class TestSnap(unittest.TestCase):
         test_file = os.path.join(os.path.dirname(__file__),
                                  'configs', 'delta.yml')
         test_file = open(test_file, 'r')
-        test_file = yaml.load(test_file)
+        test_file = yaml.load(test_file, Loader=yaml.FullLoader)
         dev = jnpr.junos.device.Device(
             host="1.1.1.1",
             user="user",
@@ -367,7 +367,7 @@ class TestSnap(unittest.TestCase):
         test_file = os.path.join(os.path.dirname(__file__),
                                  'configs', 'delta.yml')
         test_file = open(test_file, 'r')
-        test_file = yaml.load(test_file)
+        test_file = yaml.load(test_file, Loader=yaml.FullLoader)
         dev = jnpr.junos.device.Device(
             host="1.1.1.1",
             user="user",
@@ -407,7 +407,7 @@ class TestSnap(unittest.TestCase):
         test_file = os.path.join(os.path.dirname(__file__),
                                  'configs', 'test_rpc.yml')
         test_file = open(test_file, 'r')
-        test_file = yaml.load(test_file)
+        test_file = yaml.load(test_file, Loader=yaml.FullLoader)
         dev = jnpr.junos.device.Device(
             host="1.1.1.1",
             user="user",
@@ -454,7 +454,7 @@ class TestSnap(unittest.TestCase):
         test_file = os.path.join(os.path.dirname(__file__),
                                  'configs', 'bogus_testfile_1.yml')
         test_file = open(test_file, 'r')
-        test_file = yaml.load(test_file)
+        test_file = yaml.load(test_file, Loader=yaml.FullLoader)
         dev = Device(user='1.1.1.1', host='abc', passwd='xyz')
         dev.open()
         par.generate_reply(test_file, dev, '1.1.1.1_snap_mock', self.hostname, self.db)
@@ -467,7 +467,7 @@ class TestSnap(unittest.TestCase):
         test_file = os.path.join(os.path.dirname(__file__),
                                  'configs', 'bogus_testfile_2.yml')
         test_file = open(test_file, 'r')
-        test_file = yaml.load(test_file)
+        test_file = yaml.load(test_file, Loader=yaml.FullLoader)
         dev = Device(user='1.1.1.1', host='abc', passwd='xyz')
         dev.open()
         par.generate_reply(test_file, dev, '1.1.1.1_snap_mock', self.hostname, self.db)
@@ -485,7 +485,7 @@ class TestSnap(unittest.TestCase):
         test_file = os.path.join(os.path.dirname(__file__),
                                  'configs', 'bogus_testfile_3.yml')
         test_file = open(test_file, 'r')
-        test_file = yaml.load(test_file)
+        test_file = yaml.load(test_file, Loader=yaml.FullLoader)
         dev = Device(host='10.221.136.250', user='abc', passwd='xyz')
         dev.open()
         par.generate_reply(test_file, dev, 'mock.xml', self.hostname, self.db)
@@ -504,7 +504,7 @@ class TestSnap(unittest.TestCase):
         test_file = os.path.join(os.path.dirname(__file__),
                                  'configs', 'bogus_testfile_4.yml')
         test_file = open(test_file, 'r')
-        test_file = yaml.load(test_file)
+        test_file = yaml.load(test_file, Loader=yaml.FullLoader)
         dev = Device(host='10.221.136.250', user='abc', passwd='xyz')
         dev.open()
         par.generate_reply(test_file, dev, 'mock.xml', self.hostname, self.db)
@@ -523,7 +523,7 @@ class TestSnap(unittest.TestCase):
         test_file = os.path.join(os.path.dirname(__file__),
                                  'configs', 'bogus_testfile_5.yml')
         test_file = open(test_file, 'r')
-        test_file = yaml.load(test_file)
+        test_file = yaml.load(test_file, Loader=yaml.FullLoader)
         dev = Device(host='10.221.136.250', user='abc', passwd='xyz')
         dev.open()
         par.generate_reply(test_file, dev, 'mock.xml', self.hostname, self.db)

--- a/tests/unit/test_snap_new.py
+++ b/tests/unit/test_snap_new.py
@@ -37,7 +37,7 @@ class TestSnap(unittest.TestCase):
         test_file = os.path.join(os.path.dirname(__file__),
                                  'configs', 'bogus_testfile_1.yml')
         test_file = open(test_file, 'r')
-        test_file = yaml.load(test_file)
+        test_file = yaml.load(test_file, Loader=yaml.FullLoader)
         dev = Device(user='1.1.1.1', host='abc', passwd='xyz')
         dev.open()
         par.generate_reply(test_file, dev, '1.1.1.1_snap_mock' ,self.hostname, self.db )
@@ -50,7 +50,7 @@ class TestSnap(unittest.TestCase):
         test_file = os.path.join(os.path.dirname(__file__),
                                  'configs', 'bogus_testfile_2.yml')
         test_file = open(test_file, 'r')
-        test_file = yaml.load(test_file)
+        test_file = yaml.load(test_file, Loader=yaml.FullLoader)
         dev = Device(user='1.1.1.1', host='abc', passwd='xyz')
         dev.open()
         par.generate_reply(test_file, dev, '1.1.1.1_snap_mock', self.hostname, self.db)
@@ -68,7 +68,7 @@ class TestSnap(unittest.TestCase):
         test_file = os.path.join(os.path.dirname(__file__),
                                  'configs', 'bogus_testfile_3.yml')
         test_file = open(test_file, 'r')
-        test_file = yaml.load(test_file)
+        test_file = yaml.load(test_file, Loader=yaml.FullLoader)
         dev = Device(host='10.221.136.250', user='abc', passwd='xyz')
         dev.open()
         par.generate_reply(test_file, dev, 'mock.xml', self.hostname, self.db)
@@ -87,7 +87,7 @@ class TestSnap(unittest.TestCase):
         test_file = os.path.join(os.path.dirname(__file__),
                                  'configs', 'bogus_testfile_4.yml')
         test_file = open(test_file, 'r')
-        test_file = yaml.load(test_file)
+        test_file = yaml.load(test_file, Loader=yaml.FullLoader)
         dev = Device(host='10.221.136.250', user='abc', passwd='xyz')
         dev.open()
         par.generate_reply(test_file, dev, 'mock.xml', self.hostname, self.db)
@@ -106,7 +106,7 @@ class TestSnap(unittest.TestCase):
         test_file = os.path.join(os.path.dirname(__file__),
                                  'configs', 'bogus_testfile_5.yml')
         test_file = open(test_file, 'r')
-        test_file = yaml.load(test_file)
+        test_file = yaml.load(test_file, Loader=yaml.FullLoader)
         dev = Device(host='10.221.136.250', user='abc', passwd='xyz')
         dev.open()
         par.generate_reply(test_file, dev, 'mock.xml', self.hostname, self.db)

--- a/tests/unit/test_str_numeric_op.py
+++ b/tests/unit/test_str_numeric_op.py
@@ -28,7 +28,7 @@ class TestStrNumericOperators(unittest.TestCase):
                                  'configs', 'main_all-same-equal-fail.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -50,7 +50,7 @@ class TestStrNumericOperators(unittest.TestCase):
                                  'configs', 'main_all-same-fail.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -72,7 +72,7 @@ class TestStrNumericOperators(unittest.TestCase):
                                  'configs', 'main_all-same-success.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -95,7 +95,7 @@ class TestStrNumericOperators(unittest.TestCase):
                                  'configs', 'main_all-same-ignore-null_1.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -117,7 +117,7 @@ class TestStrNumericOperators(unittest.TestCase):
                                  'configs', 'main_all-same-ignore-null_2.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -139,7 +139,7 @@ class TestStrNumericOperators(unittest.TestCase):
                                  'configs', 'main_all-same-ignore-null_3.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -161,7 +161,7 @@ class TestStrNumericOperators(unittest.TestCase):
                                  'configs', 'main_all-same-ignore-null_4.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -183,7 +183,7 @@ class TestStrNumericOperators(unittest.TestCase):
                                  'configs', 'main_all-same-ignore-null_pass.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -205,7 +205,7 @@ class TestStrNumericOperators(unittest.TestCase):
                                  'configs', 'main_is-equal-item.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -227,7 +227,7 @@ class TestStrNumericOperators(unittest.TestCase):
                                  'configs', 'main_is-equal.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -249,7 +249,7 @@ class TestStrNumericOperators(unittest.TestCase):
                                  'configs', 'main_is-equal_ignore-null_1.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -271,7 +271,7 @@ class TestStrNumericOperators(unittest.TestCase):
                                  'configs', 'main_is-equal_ignore-null_2.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -293,7 +293,7 @@ class TestStrNumericOperators(unittest.TestCase):
                                  'configs', 'main_is-equal_ignore-null_3.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -316,7 +316,7 @@ class TestStrNumericOperators(unittest.TestCase):
                                  'configs', 'main_is-equal_ignore-null_4.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -338,7 +338,7 @@ class TestStrNumericOperators(unittest.TestCase):
                                  'configs', 'main_is-equal_ignore-null_5.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -361,7 +361,7 @@ class TestStrNumericOperators(unittest.TestCase):
                                  'configs', 'main_is-equal_ignore-null_6.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -384,7 +384,7 @@ class TestStrNumericOperators(unittest.TestCase):
                                  'configs', 'main_not-equal.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -406,7 +406,7 @@ class TestStrNumericOperators(unittest.TestCase):
                                  'configs', 'main_not-equal.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -428,7 +428,7 @@ class TestStrNumericOperators(unittest.TestCase):
                                  'configs', 'main_not-equal_ignore-null_1.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -450,7 +450,7 @@ class TestStrNumericOperators(unittest.TestCase):
                                  'configs', 'main_not-equal_ignore-null_2.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -472,7 +472,7 @@ class TestStrNumericOperators(unittest.TestCase):
                                  'configs', 'main_not-equal_ignore-null_3.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -494,7 +494,7 @@ class TestStrNumericOperators(unittest.TestCase):
                                  'configs', 'main_not-equal_ignore-null_4.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -516,7 +516,7 @@ class TestStrNumericOperators(unittest.TestCase):
                                  'configs', 'main_not-equal_ignore-null_5.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -538,7 +538,7 @@ class TestStrNumericOperators(unittest.TestCase):
                                  'configs', 'main_not-exists.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -560,7 +560,7 @@ class TestStrNumericOperators(unittest.TestCase):
                                  'configs', 'main_not-exists_ignore-null_fail.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -582,7 +582,7 @@ class TestStrNumericOperators(unittest.TestCase):
                                  'configs', 'main_not-exists_ignore-null.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         # print main_file
         oper = comp.generate_test_files(
             main_file,
@@ -605,7 +605,7 @@ class TestStrNumericOperators(unittest.TestCase):
                                  'configs', 'main_not-exists_fail.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
 
         oper = comp.generate_test_files(
             main_file,
@@ -628,7 +628,7 @@ class TestStrNumericOperators(unittest.TestCase):
                                  'configs', 'main_exists.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -650,7 +650,7 @@ class TestStrNumericOperators(unittest.TestCase):
                                  'configs', 'main_exists_ignore-null_fail.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -672,7 +672,7 @@ class TestStrNumericOperators(unittest.TestCase):
                                  'configs', 'main_exists_ignore-null_skip.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -694,7 +694,7 @@ class TestStrNumericOperators(unittest.TestCase):
                                  'configs', 'main_exists.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,

--- a/tests/unit/test_string_op.py
+++ b/tests/unit/test_string_op.py
@@ -25,7 +25,7 @@ class TestStringOperators(unittest.TestCase):
                                  'configs', 'main_contains.yml')
         config_file = open(conf_file, 'r')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -45,7 +45,7 @@ class TestStringOperators(unittest.TestCase):
                                  'configs', 'main_contains.yml')
         config_file = open(conf_file, 'r')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -66,7 +66,7 @@ class TestStringOperators(unittest.TestCase):
                                  'configs', 'main_contains_ignore-null_fail.yml')
         config_file = open(conf_file, 'r')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -86,7 +86,7 @@ class TestStringOperators(unittest.TestCase):
                                  'configs', 'main_contains_ignore-null_fail_1.yml')
         config_file = open(conf_file, 'r')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -106,7 +106,7 @@ class TestStringOperators(unittest.TestCase):
                                  'configs', 'main_contains_ignore-null_skip.yml')
         config_file = open(conf_file, 'r')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -126,7 +126,7 @@ class TestStringOperators(unittest.TestCase):
                                  'configs', 'main_contains_ignore-null_skip_1.yml')
         config_file = open(conf_file, 'r')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -146,7 +146,7 @@ class TestStringOperators(unittest.TestCase):
                                  'configs', 'main_contains_ignore-null_pass.yml')
         config_file = open(conf_file, 'r')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -166,7 +166,7 @@ class TestStringOperators(unittest.TestCase):
                                  'configs', 'main_is-in.yml')
         config_file = open(conf_file, 'r')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -186,7 +186,7 @@ class TestStringOperators(unittest.TestCase):
                                  'configs', 'main_is-in.yml')
         config_file = open(conf_file, 'r')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -206,7 +206,7 @@ class TestStringOperators(unittest.TestCase):
                                  'configs', 'main_is-in_ignore-null_fail.yml')
         config_file = open(conf_file, 'r')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -226,7 +226,7 @@ class TestStringOperators(unittest.TestCase):
                                  'configs', 'main_is-in_ignore-null_fail_1.yml')
         config_file = open(conf_file, 'r')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -246,7 +246,7 @@ class TestStringOperators(unittest.TestCase):
                                  'configs', 'main_is-in_ignore-null_skip.yml')
         config_file = open(conf_file, 'r')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -266,7 +266,7 @@ class TestStringOperators(unittest.TestCase):
                                  'configs', 'main_is-in_ignore-null_skip_1.yml')
         config_file = open(conf_file, 'r')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -286,7 +286,7 @@ class TestStringOperators(unittest.TestCase):
                                  'configs', 'main_is-in_ignore-null_pass.yml')
         config_file = open(conf_file, 'r')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -306,7 +306,7 @@ class TestStringOperators(unittest.TestCase):
                                  'configs', 'main_not-in.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -326,7 +326,7 @@ class TestStringOperators(unittest.TestCase):
                                  'configs', 'main_not-in_ignore-null_fail.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -346,7 +346,7 @@ class TestStringOperators(unittest.TestCase):
                                  'configs', 'main_not-in_ignore-null_fail_1.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -366,7 +366,7 @@ class TestStringOperators(unittest.TestCase):
                                  'configs', 'main_not-in_ignore-null_skip.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -386,7 +386,7 @@ class TestStringOperators(unittest.TestCase):
                                  'configs', 'main_not-in_ignore-null_skip_1.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -406,7 +406,7 @@ class TestStringOperators(unittest.TestCase):
                                  'configs', 'main_not-in_ignore-null_pass.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,
@@ -426,7 +426,7 @@ class TestStringOperators(unittest.TestCase):
                                  'configs', 'main_not-in.yml')
         mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
         config_file = open(conf_file, 'r')
-        main_file = yaml.load(config_file)
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
         oper = comp.generate_test_files(
             main_file,
             self.hostname,


### PR DESCRIPTION
Credit: Randy Booth (rbooth@juniper.net)

### What does this PR do?

Fixes the following warning: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.

### What issues does this PR fix or reference?

#337 

### Tests written?

No
