### PR TITLE
Update setup.py to support MacOS Python 3.X

### DIFF
--- a/lib/jnpr/jsnapy/__init__.py
+++ b/lib/jnpr/jsnapy/__init__.py
@@ -24,8 +24,9 @@ def get_config_location(file='jsnapy.cfg'):
     p_locations = []
     if 'JSNAPY_HOME' in os.environ:
         p_locations = [os.environ['JSNAPY_HOME']]
-
-    if hasattr(sys, 'real_prefix'):
+        
+    # Added (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix): to support Python 3.X venv environments.
+    if hasattr(sys, 'real_prefix') or (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix):
         p_locations.extend([os.path.join(os.path.expanduser("~"), '.jsnapy'),
                             os.path.join(sys.prefix, 'etc', 'jsnapy')])
     elif 'win32' in sys.platform:

--- a/lib/jnpr/jsnapy/__init__.py
+++ b/lib/jnpr/jsnapy/__init__.py
@@ -19,14 +19,22 @@ except NameError:
 class DirStore:
     custom_dir = None
 
+# Function added by @gcasella
+# To check if the user is currently running the installation inside of a virtual environment that was installed using the `python3 -m venv venv` command.
+def venv_check():
+
+    if hasattr(sys, 'real_prefix') or (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix):
+        return True
+    else:
+        return False
 
 def get_config_location(file='jsnapy.cfg'):
     p_locations = []
     if 'JSNAPY_HOME' in os.environ:
         p_locations = [os.environ['JSNAPY_HOME']]
-        
-    # Added (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix): to support Python 3.X venv environments.
-    if hasattr(sys, 'real_prefix') or (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix):
+
+    # Modified by @gcasella to use the function created on lines 22-29.
+    if venv_check() is True:
         p_locations.extend([os.path.join(os.path.expanduser("~"), '.jsnapy'),
                             os.path.join(sys.prefix, 'etc', 'jsnapy')])
     elif 'win32' in sys.platform:

--- a/lib/jnpr/jsnapy/setup_logging.py
+++ b/lib/jnpr/jsnapy/setup_logging.py
@@ -10,6 +10,7 @@ import yaml
 import logging.config
 from jnpr.jsnapy import get_config_location
 from jnpr.jsnapy import get_path
+from jnpr.jsnapy import venv_check
 import sys
 
 def setup_logging(
@@ -30,7 +31,8 @@ def setup_logging(
     ###################################
     # Creating Folder path for SNAPSHOT
     ###################################
-    if 'win32' not in sys.platform and not hasattr(sys, 'real_prefix'):
+    # Modified by @gcasella to use the function created on lines 24-29 in the __init__.py.
+    if 'win32' not in sys.platform and not venv_check:
         snapshots_path = get_path('DEFAULT', 'snapshot_path')
         snapshots_path = os.path.expanduser(snapshots_path)
         if not os.path.isdir(snapshots_path):

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,8 @@ class OverrideInstall(install):
         mode = 0o777
         install.run(self)
 
-        if 'win32' not in sys.platform and not hasattr(sys, 'real_prefix'):
+        # Added and not (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix) to support Virtual Enviroments in Python 3.X for the logging.yml export        
+        if 'win32' not in sys.platform and not hasattr(sys, 'real_prefix') and not (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix):
             dir_mode = 0o755
             file_mode = 0o644
             os.chmod(dir_path, dir_mode)

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ def set_logging_path(path):
                     ###
                     # Added (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix)) for Python 3.X Support of Virtual Env
                     ###
-                    if hasattr(sys, 'real_prefix') or (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix)):
+                    if hasattr(sys, 'real_prefix') or (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix):
                         value['filename'] = (os.path.join
                                              (sys.prefix,
                                               'var/logs/jsnapy/jsnapy.log'))
@@ -56,9 +56,9 @@ class OverrideInstall(install):
             # user is working in python virtual environment
             # --------------------------------
             ###
-            # Added (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix)) for Python 3.X Support of Virtual Env
+            # Added (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix) for Python 3.X Support of Virtual Env
             ###
-            if hasattr(sys, 'real_prefix') or (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix)):
+            if hasattr(sys, 'real_prefix') or (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix):
                 self.install_data = os.path.join(sys.prefix, 'etc',
                                                  'jsnapy')
             elif 'win32' in sys.platform:
@@ -102,9 +102,9 @@ class OverrideInstall(install):
             config.set('DEFAULT', 'test_file_path',
                        os.path.join(dir_path, 'testfiles'))
             ###
-            # Added (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix)) for Python 3.X venv Support
+            # Added (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix) for Python 3.X venv Support
             ###
-            if hasattr(sys, 'real_prefix') or (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix)):
+            if hasattr(sys, 'real_prefix') or (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix):
                 default_config_location = os.path.join(sys.prefix,
                                                        'etc',
                                                        'jsnapy', 'jsnapy.cfg')
@@ -133,9 +133,9 @@ class OverrideInstall(install):
                                 default_config_location)
             
             ###
-            # Added (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix)) for Python 3.X venv support.
+            # Added (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix) for Python 3.X venv support.
             ###
-            if hasattr(sys, 'real_prefix') or (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix)):
+            if hasattr(sys, 'real_prefix') or (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix):
                 path = os.path.join(sys.prefix, 'etc', 'jsnapy', 'logging.yml')
                 set_logging_path(path)
             elif 'win32' in sys.platform:
@@ -160,8 +160,9 @@ os_data_file = []
 # Specifying only 'samples' means 'install_data Path'/samples
 # ----------------------------
 ###
-# Added (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix)) for Python 3.X venv Support
-if hasattr(sys, 'real_prefix') or (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix)):
+# Added (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix) for Python 3.X venv Support
+###
+if hasattr(sys, 'real_prefix') or (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix):
     os_data_file = [('.', ['lib/jnpr/jsnapy/logging.yml']),
                     ('../../var/logs/jsnapy', log_files),
                     ('.', ['lib/jnpr/jsnapy/jsnapy.cfg']),

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,14 @@ if sys.version < '3':
 else:
     from configparser import ConfigParser
 
+# Function added by @gcasella
+# To check if the user is currently running the installation inside of a virtual environment that was installed using the `python3 -m venv venv` command.
+def venv_check():
+
+    if hasattr(sys, 'real_prefix') or (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix):
+        return True
+    else:
+        return False
 
 def set_logging_path(path):
     if os.path.exists(path):
@@ -27,10 +35,8 @@ def set_logging_path(path):
                 if handler == 'console':
                     pass
                 else:
-                    ###
-                    # Added (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix)) for Python 3.X Support of Virtual Env
-                    ###
-                    if hasattr(sys, 'real_prefix') or (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix):
+                    # Modified by @gcasella to use the function created on lines 20-25.
+                    if venv_check() is True:
                         value['filename'] = (os.path.join
                                              (sys.prefix,
                                               'var/logs/jsnapy/jsnapy.log'))
@@ -55,10 +61,8 @@ class OverrideInstall(install):
             # hasattr(sys,'real_prefix') checks whether the
             # user is working in python virtual environment
             # --------------------------------
-            ###
-            # Added (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix) for Python 3.X Support of Virtual Env
-            ###
-            if hasattr(sys, 'real_prefix') or (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix):
+            # Modified by @gcasella to use the function created on lines 20-25.
+            if venv_check() is True:
                 self.install_data = os.path.join(sys.prefix, 'etc',
                                                  'jsnapy')
             elif 'win32' in sys.platform:
@@ -71,8 +75,8 @@ class OverrideInstall(install):
         mode = 0o777
         install.run(self)
 
-        # Added and not (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix) to support Virtual Enviroments in Python 3.X for the logging.yml export        
-        if 'win32' not in sys.platform and not hasattr(sys, 'real_prefix') and not (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix):
+        # Modified by @gcasella to use the function created on lines 20-25.
+        if 'win32' not in sys.platform and not venv_check():
             dir_mode = 0o755
             file_mode = 0o644
             os.chmod(dir_path, dir_mode)
@@ -102,10 +106,9 @@ class OverrideInstall(install):
                        os.path.join(dir_path, 'snapshots'))
             config.set('DEFAULT', 'test_file_path',
                        os.path.join(dir_path, 'testfiles'))
-            ###
-            # Added (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix) for Python 3.X venv Support
-            ###
-            if hasattr(sys, 'real_prefix') or (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix):
+
+            # Modified by @gcasella to use the function created on lines 20-25.
+            if venv_check() is True:
                 default_config_location = os.path.join(sys.prefix,
                                                        'etc',
                                                        'jsnapy', 'jsnapy.cfg')
@@ -133,10 +136,8 @@ class OverrideInstall(install):
                 raise Exception('jsnapy.cfg not found at ' +
                                 default_config_location)
             
-            ###
-            # Added (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix) for Python 3.X venv support.
-            ###
-            if hasattr(sys, 'real_prefix') or (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix):
+            # Modified by @gcasella to use the function created on lines 20-25.
+            if venv_check() is True:
                 path = os.path.join(sys.prefix, 'etc', 'jsnapy', 'logging.yml')
                 set_logging_path(path)
             elif 'win32' in sys.platform:
@@ -160,10 +161,9 @@ os_data_file = []
 # by self.install_data path.
 # Specifying only 'samples' means 'install_data Path'/samples
 # ----------------------------
-###
-# Added (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix) for Python 3.X venv Support
-###
-if hasattr(sys, 'real_prefix') or (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix):
+
+# Modified by @gcasella to use the function created on lines 20-25.
+if venv_check() is True:
     os_data_file = [('.', ['lib/jnpr/jsnapy/logging.yml']),
                     ('../../var/logs/jsnapy', log_files),
                     ('.', ['lib/jnpr/jsnapy/jsnapy.cfg']),

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,10 @@ def set_logging_path(path):
                 if handler == 'console':
                     pass
                 else:
-                    if hasattr(sys, 'real_prefix'):
+                    ###
+                    # Added (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix)) for Python 3.X Support of Virtual Env
+                    ###
+                    if hasattr(sys, 'real_prefix') or (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix)):
                         value['filename'] = (os.path.join
                                              (sys.prefix,
                                               'var/logs/jsnapy/jsnapy.log'))
@@ -52,7 +55,10 @@ class OverrideInstall(install):
             # hasattr(sys,'real_prefix') checks whether the
             # user is working in python virtual environment
             # --------------------------------
-            if hasattr(sys, 'real_prefix'):
+            ###
+            # Added (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix)) for Python 3.X Support of Virtual Env
+            ###
+            if hasattr(sys, 'real_prefix') or (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix)):
                 self.install_data = os.path.join(sys.prefix, 'etc',
                                                  'jsnapy')
             elif 'win32' in sys.platform:
@@ -95,8 +101,10 @@ class OverrideInstall(install):
                        os.path.join(dir_path, 'snapshots'))
             config.set('DEFAULT', 'test_file_path',
                        os.path.join(dir_path, 'testfiles'))
-
-            if hasattr(sys, 'real_prefix'):
+            ###
+            # Added (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix)) for Python 3.X venv Support
+            ###
+            if hasattr(sys, 'real_prefix') or (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix)):
                 default_config_location = os.path.join(sys.prefix,
                                                        'etc',
                                                        'jsnapy', 'jsnapy.cfg')
@@ -123,8 +131,11 @@ class OverrideInstall(install):
             else:
                 raise Exception('jsnapy.cfg not found at ' +
                                 default_config_location)
-
-            if hasattr(sys, 'real_prefix'):
+            
+            ###
+            # Added (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix)) for Python 3.X venv support.
+            ###
+            if hasattr(sys, 'real_prefix') or (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix)):
                 path = os.path.join(sys.prefix, 'etc', 'jsnapy', 'logging.yml')
                 set_logging_path(path)
             elif 'win32' in sys.platform:
@@ -148,8 +159,9 @@ os_data_file = []
 # by self.install_data path.
 # Specifying only 'samples' means 'install_data Path'/samples
 # ----------------------------
-
-if hasattr(sys, 'real_prefix'):
+###
+# Added (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix)) for Python 3.X venv Support
+if hasattr(sys, 'real_prefix') or (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix)):
     os_data_file = [('.', ['lib/jnpr/jsnapy/logging.yml']),
                     ('../../var/logs/jsnapy', log_files),
                     ('.', ['lib/jnpr/jsnapy/jsnapy.cfg']),

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -36,7 +36,8 @@ class TestCheck(unittest.TestCase):
 
     @patch('os.path.isfile')
     def test_config_location_etc(self, mock_is_file):
-        if hasattr(sys, 'real_prefix'):
+        # Add or (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix) for Python 3.X venv Support.
+        if hasattr(sys, 'real_prefix') or (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix):
             mock_is_file.side_effect = lambda arg: arg in [os.path.join(sys.prefix, 'etc',
                                                                         'jsnapy',
                                                       'jsnapy.cfg')]

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -4,7 +4,7 @@ import sys
 import yaml
 from mock import patch, MagicMock
 from nose.plugins.attrib import attr
-from jnpr.jsnapy import get_config_location, get_path, DirStore
+from jnpr.jsnapy import get_config_location, get_path, DirStore, venv_check
 @attr('unit')
 class TestCheck(unittest.TestCase):
 
@@ -36,8 +36,8 @@ class TestCheck(unittest.TestCase):
 
     @patch('os.path.isfile')
     def test_config_location_etc(self, mock_is_file):
-        # Add or (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix) for Python 3.X venv Support.
-        if hasattr(sys, 'real_prefix') or (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix):
+        # Modified by @gcasella to use the function created on lines in __init__.py.
+        if venv_check():
             mock_is_file.side_effect = lambda arg: arg in [os.path.join(sys.prefix, 'etc',
                                                                         'jsnapy',
                                                       'jsnapy.cfg')]


### PR DESCRIPTION
### What does this PR do?
Enables JSNAPy to be installed properly in a virtual environment for Python 3.X.

### What issues does this PR fix or reference?
The setup.py does not find the virtual environment in Python 3.X, it attempts to install JSNAPy files in the main filesystem as seen below;

![image](https://user-images.githubusercontent.com/7719536/72848503-c3f87600-3c72-11ea-95ac-7e0f560a90ca.png)

### Tests written?

No

### Additional comments:

I've noticed that this setup.py does not work when trying to execute
"pip install jsnapy" from a Python 3.X Virtual environment.

It appears that Python 3.X does not use the sys.real_prefix attribute any more.
I found some documentation here https://stackoverflow.com/questions/1871549/determine-if-python-is-running-inside-virtualenv showing that it is moved to base_prefix.

What i've added will check sys.base_prefix and compare it to sys.prefix, if it doesn't match, than you're in a virtual environment. 

Outside of VirtualEnv;

Gian-Lucas-MacBook-Pro:~ gianluca.casella$ python3.8
Python 3.8.1 (v3.8.1:1b293b6006, Dec 18 2019, 14:08:53) 
[Clang 6.0 (clang-600.0.57)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import sys
>>> sys.base_prefix
'/Library/Frameworks/Python.framework/Versions/3.8'
>>> sys.prefix
'/Library/Frameworks/Python.framework/Versions/3.8'
>>> quit()



Inside VirtualEnv:
Gian-Lucas-MacBook-Pro:~ gianluca.casella$ source venv/bin/activate
(venv) Gian-Lucas-MacBook-Pro:~ gianluca.casella$ python
Python 3.8.1 (v3.8.1:1b293b6006, Dec 18 2019, 14:08:53) 
[Clang 6.0 (clang-600.0.57)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import sys
>>> sys.base_prefix
'/Library/Frameworks/Python.framework/Versions/3.8'
>>> sys.prefix
'/Users/gianluca.casella/venv'