### PR TITLE
For empty id in check-operation, id needs to be handled separately

### DIFF
--- a/lib/jnpr/jsnapy/operator.py
+++ b/lib/jnpr/jsnapy/operator.py
@@ -208,13 +208,17 @@ class Operator:
         for path in nodes:
          #   i = i + 1
             xlist = []
+            val = []
             for id in id_list:
+                # if "." empty id is passed, do not process it, just append it.
+                if id == ".":
+                    val.append(tuple(["."]))
+                    continue
                 id_nodes = path.findall(id)
                 if self._is_ignore_null(ignore_null) and not id_nodes:
                     continue
                 xlist.append(id_nodes)
             # xlist = [path.findall(id) for id in id_list]
-            val = []
             for values in xlist:
                 if values is not None:
                     if isinstance(values, list):

--- a/tests/unit/configs/delta_empty_id.yml
+++ b/tests/unit/configs/delta_empty_id.yml
@@ -1,0 +1,10 @@
+check_chassis_fpc:
+  - command: show chassis fpc
+  - item: 
+      xpath: //fpc
+      id: "."
+      tests:
+        - delta: memory-heap-utilization, 50%
+          info: "Test Succeeded!! Memory heap utilisation of the FPC {{id_0}} has changed less than 50%"
+          err: "Test Failed!!! Memory heap utilisation of the FPC {{id_0}} has changed less than 50%"
+          ignore-null: True

--- a/tests/unit/configs/main_delta_empty_id.yml
+++ b/tests/unit/configs/main_delta_empty_id.yml
@@ -1,0 +1,14 @@
+
+# for one device, can be given like this:
+hosts:
+  - device: 1.1.1.1
+    username : abc
+    passwd: xyz
+tests:
+  - delta_empty_id.yml
+
+sqlite:
+  - store_in_sqlite: yes
+    check_from_sqlite: no
+    database_name: jbb.db
+

--- a/tests/unit/test_comparison_op.py
+++ b/tests/unit/test_comparison_op.py
@@ -535,6 +535,28 @@ class TestComparisonOperator(unittest.TestCase):
         self.assertEqual(oper.no_failed, 0)
 
     @patch('jnpr.jsnapy.check.get_path')
+    def test_delta_empty_id(self, mock_path):
+        self.chk = True
+        comp = Comparator()
+        conf_file = os.path.join(os.path.dirname(__file__),
+                                 'configs', 'main_delta_empty_id.yml')
+        mock_path.return_value = os.path.join(os.path.dirname(__file__), 'configs')
+        config_file = open(conf_file, 'r')
+        main_file = yaml.load(config_file, Loader=yaml.FullLoader)
+        oper = comp.generate_test_files(
+            main_file,
+            self.hostname,
+            self.chk,
+            self.diff,
+            self.db,
+            self.snap_del,
+            "snap_delta_pre",
+            self.action,
+            "snap_delta_post")
+        self.assertEqual(oper.no_passed, 1)
+        self.assertEqual(oper.no_failed, 0)
+
+    @patch('jnpr.jsnapy.check.get_path')
     def test_delta_fail(self, mock_path):
         self.chk = True
         comp = Comparator()


### PR DESCRIPTION
### What does this PR do?
For empty id, it doesn't check for node values.

### What issues does this PR fix or reference?
For some snapshot it was causing error as id-value gave None.
