### PR TITLE
options in get-config rpc needs to be updated

### DIFF
--- a/lib/jnpr/jsnapy/snap.py
+++ b/lib/jnpr/jsnapy/snap.py
@@ -278,8 +278,7 @@ class Parser:
                         rpc.replace(
                             '-',
                             '_'))(
-                        options={
-                            'format': reply_format},
+                        options=options_rpc,
                         **kwargs)
                 else:
                     self.logger_snap.error(

--- a/lib/jnpr/jsnapy/snap.py
+++ b/lib/jnpr/jsnapy/snap.py
@@ -269,6 +269,10 @@ class Parser:
                     #     "Taking snapshot of RPC: %s" %
                     #     rpc,
                     #     extra=self.log_detail)
+                    options_rpc = {'format': reply_format}
+                    if 'options' in kwargs:
+                        options_rpc.update(kwargs['options'])
+                        kwargs.pop('options')
                     rpc_reply = getattr(
                         dev.rpc,
                         rpc.replace(


### PR DESCRIPTION
### What does this PR do?
Options argument passed with get-config rpc gives error

### Previous Behavior
Options argument passed with get-config rpc were not executing properly.

### New Behavior
Options argument passed with get-config rpc updated properly in the execution

