### PR TITLE
snap_temp file to be used for snapcheck

### DIFF
--- a/lib/jnpr/jsnapy/jsnapy.py
+++ b/lib/jnpr/jsnapy/jsnapy.py
@@ -858,6 +858,9 @@ class SnapAdmin:
         :return: return list of object of testop.Operator containing test details or list of dictionary of object
                     of testop.Operator containing test details for each stored snapshot
         """
+        if pre_file is None:
+            pre_file = "snap_temp"
+            self.snap_del = True
         return self.action_api_based(dev, data, pre_file, "snapcheck", folder, local=local)
 
     def check(self, data, pre_file=None, post_file=None, dev=None, folder=None):

--- a/lib/jnpr/jsnapy/jsnapy.py
+++ b/lib/jnpr/jsnapy/jsnapy.py
@@ -732,6 +732,7 @@ class SnapAdmin:
         :return: return list of object of testop.Operator containing test details or list of dictionary of object
                     of testop.Operator containing test details for each stored snapshot
         """
+        self.host_list = []
         try:
             host = config_data.get('hosts')[0]
         except Exception as ex:

--- a/tests/unit/test_jsnapy.py
+++ b/tests/unit/test_jsnapy.py
@@ -333,6 +333,21 @@ class TestSnapAdmin(unittest.TestCase):
         config_data = yaml.load(config_data, Loader=yaml.FullLoader)
         mock_connect.assert_called_with('1.1.1.1', 'abc', 'xyz', 'mock_pre', config_data, 'snapcheck', None)
 
+    @patch('jnpr.jsnapy.jsnapy.SnapAdmin.connect')
+    def test_extract_data_text_string(self, mock_connect):
+        js = SnapAdmin()
+        config_data = """
+                hosts:
+                  - device: 1.1.1.1
+                    username : abc
+                    passwd: xyz
+                tests:
+                  - test_anything.yml
+                """
+        js.snapcheck(config_data)
+        config_data = yaml.load(config_data, Loader=yaml.FullLoader)
+        mock_connect.assert_called_with('1.1.1.1', 'abc', 'xyz', 'snap_temp', config_data, 'snapcheck', None)
+
     def test_extract_data_error(self):
         with self.assertRaises(Exception):
             js = SnapAdmin()

--- a/tests/unit/test_jsnapy.py
+++ b/tests/unit/test_jsnapy.py
@@ -334,7 +334,7 @@ class TestSnapAdmin(unittest.TestCase):
         mock_connect.assert_called_with('1.1.1.1', 'abc', 'xyz', 'mock_pre', config_data, 'snapcheck', None)
 
     @patch('jnpr.jsnapy.jsnapy.SnapAdmin.connect')
-    def test_extract_data_text_string(self, mock_connect):
+    def test_snapcheck_no_file_passed(self, mock_connect):
         js = SnapAdmin()
         config_data = """
                 hosts:


### PR DESCRIPTION
### What does this PR do?
snap_temp file to be used for snapcheck if not provided in command line or ansible module.

### What issues does this PR fix or reference?
https://github.com/Juniper/ansible-junos-stdlib/issues/539