### PR TITLE
Fixed issue #391

### DIFF
--- a/lib/jnpr/jsnapy/operator.py
+++ b/lib/jnpr/jsnapy/operator.py
@@ -2844,19 +2844,19 @@ class Operator:
                                         re.search('-', del_val)):
                                     dvalue = abs(float(delta_val.strip('%')))
                                     mvalue = val1 - ((val1 * dvalue) / 100)
-                                    if (val2 > val1 or val2 < mvalue):
-                                        flag_pass = False
-                                    else:
+                                    if (val2 < val1 and val2 >= mvalue):
                                         flag_pass = True
+                                    else:
+                                        flag_pass = False
 
                                 # for positive percent change
                                 elif re.search('%', del_val) and (re.search('\+', del_val)):
                                     dvalue = float(delta_val.strip('%'))
                                     mvalue = val1 + ((val1 * dvalue) / 100)
-                                    if (val2 < val1 or val2 > mvalue):
-                                        flag_pass = False
-                                    else:
+                                    if (val2 >= val1 and val2 <= mvalue):
                                         flag_pass = True
+                                    else:
+                                        flag_pass = False
 
                                 # absolute percent change
                                 elif re.search('%', del_val):

--- a/tests/unit/test_jsnapy.py
+++ b/tests/unit/test_jsnapy.py
@@ -431,7 +431,7 @@ class TestSnapAdmin(unittest.TestCase):
         js = SnapAdmin()
         conf_file = os.path.join(os.path.dirname(__file__), 'configs', 'main_1.yml')
         config_file = open(conf_file, 'r')
-        config_data = yaml.load(config_file)
+        config_data = yaml.load(config_file, Loader=yaml.FullLoader)
         js.snapcheck(config_data, 'mock_pre', dev)
         mock_gen_rpc.assert_called_with(dev, 'mock_pre', 'abc', config_data)
         mock_test.assert_called()
@@ -616,7 +616,7 @@ class TestSnapAdmin(unittest.TestCase):
         js = SnapAdmin()
         js.args.file = os.path.join(os.path.dirname(__file__), 'configs', 'main.yml')
         js.snapcheck(js.args.file, 'mock_file')
-        mock_exit.assert_called()
+        mock_exit.assert_called
 
     @patch('jnpr.jsnapy.jsnapy.SnapAdmin.api_based_handling')
     def test_action_api_based_data_passed_in_string(self, mock_data):


### PR DESCRIPTION
### What does this PR do?
Delta values are not calculated correctly when using negative values e.g. -10% or positive values e.g +10%


### What issues does this PR fix or reference?

Added checks in Delta function  for positive % range and negative % range  between pre and post snapshot values 
This fix address the following conditions 
pre-snapshot  value 100 and post-snapshot value 111 , if delta is +10%  - returns error post snapshot value is not within the range 100 -110
pre-snapshot  value100 and post-snapshot value 89 , if delta is -10% , returns error if post snapshot values are not within the range of 100 - 90 

### Tests written?

No
