### PR TITLE
Extension of fix for #394

### DIFF
--- a/lib/jnpr/jsnapy/operator.py
+++ b/lib/jnpr/jsnapy/operator.py
@@ -2896,7 +2896,7 @@ class Operator:
                                 predict,
                                 postdict,
                                 data1[k],
-                                None,
+                                etree.Element("NoNode"),
                                 x_path,
                                 ele_list[0],
                                 err_mssg,
@@ -2914,7 +2914,7 @@ class Operator:
                             predict, postdict = self._get_nodevalue(
                                 predict,
                                 postdict,
-                                None,
+                                etree.Element("NoNode"),
                                 data2[k],
                                 x_path,
                                 ele_list[0],


### PR DESCRIPTION
Replaced None with etree.Element("NoNode") in 2 more places

### What does this PR do?
Fixes Attribute error when id element does not exist in pre but is referenced

### What issues does this PR fix or reference?
Extension to 394

### Previous Behavior
Attribute Error

### New Behavior
Proper Info Displayed

### Tests written?

Yes
run pre
Add new static route
"set routing-options static route 192.168.1.1/32 next-hop 10.255.1.2"
run post

```
test_command_routes:
  - command: show route
  - iterate:
      xpath: '/route-information/route-table/rt'
      id: rt-destination
      tests:
         - no-diff: rt-destination
           err: "Test Failed!! rt-destination got changed, before it was <{{pre['rt-destination']}}>
                 NOW it is <{{post['rt-destination']}}>"
           info: "Test Passed!! rt-destination is same, before it is <{{pre['rt-destination']}}>
                  NOW it is <{{post['rt-destination']}}>"
         - no-diff: rt-entry/nh/to
           err: "Test Failed!! Next-Hop changed, before it was <{{pre['rt-destination']}}> via <{{pre['rt-entry/nh/to']}}>
                  NOW it is <{{post['rt-destination']}}> via <{{post['rt-entry/nh/to']}}>"
           info: "Test Passed!! Next-Hop is same, before it was <{{pre['rt-destination']}}> via <{{pre['rt-entry/nh/to']}}>
                   NOW it is still via <{{post['rt-entry/nh/to']}}>"
```

Old:
```
**************************** Command: show route ****************************
Test Failed!! rt-destination got changed, before it was <None> NOW it is <192.168.1.1/32>
FAIL | All "rt-destination" is not same in pre and post snapshot [ 20 value matched / 1 value failed ]
ERROR!! AttributeError 
Complete Message: 'NoneType' object has no attribute 'findtext'
```

New:
```
**************************** Command: show route ****************************
Test Failed!! rt-destination got changed, before it was <None> NOW it is <192.168.1.1/32>
FAIL | All "rt-destination" is not same in pre and post snapshot [ 20 value matched / 1 value failed ]
Test Failed!! Next-Hop changed, before it was <None> via <None> NOW it is <192.168.1.1/32> via <10.255.1.2>
FAIL | All "rt-entry/nh/to" is not same in pre and post snapshot [ 20 value matched / 1 value failed ]
```
