### PR TITLE
Address issue #400

### DIFF
--- a/lib/jnpr/jsnapy/jsnapy.py
+++ b/lib/jnpr/jsnapy/jsnapy.py
@@ -666,7 +666,7 @@ class SnapAdmin:
             try:
                 dev.open()
             except ConnectAuthError as ex:
-                if password is None and action is None:
+                if password is None:
                     password = getpass.getpass(
                         "\nEnter Password for username <%s> : " % username
                     )


### PR DESCRIPTION
Issue #400 fix, line 669 remove "and action None" from else statement to allow password prompt to appear
Note, I do not know if this has implications outside my scenarios but all my tests are now working as expected

### What does this PR do?
jsnapy with no username/password (where it should be prompted) dies after username

### What issues does this PR fix or reference?
#400 

### Previous Behavior
```
ddivins@ddivins-mbp jsnap % jsnapy --snap pre -f config_check.yml -v
jsnapy.cfg file location used : /Users/ddivins/Library/CloudStorage/OneDrive-JuniperNetworks,Inc/Documents/PycharmProjects/jsnap/venv/etc/jsnapy
Configuration file location used : /etc/jsnapy
Connecting to device 172.25.92.59 ................

Enter User name: lab

ERROR occurred ConnectAuthError(172.25.92.59)
Exception in thread Thread-1 (connect):
Traceback (most recent call last):
  File "/Users/ddivins/Library/CloudStorage/OneDrive-JuniperNetworks,Inc/Documents/PycharmProjects/jsnap/venv/lib/python3.10/site-packages/jnpr/junos/device.py", line 1347, in open
    self._conn = netconf_ssh.connect(
  File "/Users/ddivins/Library/CloudStorage/OneDrive-JuniperNetworks,Inc/Documents/PycharmProjects/jsnap/venv/lib/python3.10/site-packages/ncclient/manager.py", line 168, in connect
    return connect_ssh(*args, **kwds)
  File "/Users/ddivins/Library/CloudStorage/OneDrive-JuniperNetworks,Inc/Documents/PycharmProjects/jsnap/venv/lib/python3.10/site-packages/ncclient/manager.py", line 135, in connect_ssh
    session.connect(*args, **kwds)
  File "/Users/ddivins/Library/CloudStorage/OneDrive-JuniperNetworks,Inc/Documents/PycharmProjects/jsnap/venv/lib/python3.10/site-packages/ncclient/transport/ssh.py", line 362, in connect
    self._auth(username, password, key_filenames, allow_agent, look_for_keys)
  File "/Users/ddivins/Library/CloudStorage/OneDrive-JuniperNetworks,Inc/Documents/PycharmProjects/jsnap/venv/lib/python3.10/site-packages/ncclient/transport/ssh.py", line 466, in _auth
    raise AuthenticationError("No authentication methods available")
ncclient.transport.errors.AuthenticationError: No authentication methods available

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/ddivins/Library/CloudStorage/OneDrive-JuniperNetworks,Inc/Documents/PycharmProjects/jsnap/venv/lib/python3.10/site-packages/jnpr/jsnapy/jsnapy.py", line 667, in connect
    dev.open()
  File "/Users/ddivins/Library/CloudStorage/OneDrive-JuniperNetworks,Inc/Documents/PycharmProjects/jsnap/venv/lib/python3.10/site-packages/jnpr/junos/device.py", line 1366, in open
    raise EzErrors.ConnectAuthError(self)
jnpr.junos.exception.ConnectAuthError: ConnectAuthError(172.25.92.59)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/threading.py", line 1009, in _bootstrap_inner
    self.run()
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/threading.py", line 946, in run
    self._target(*self._args, **self._kwargs)
  File "/Users/ddivins/Library/CloudStorage/OneDrive-JuniperNetworks,Inc/Documents/PycharmProjects/jsnap/venv/lib/python3.10/site-packages/jnpr/jsnapy/jsnapy.py", line 689, in connect
    raise Exception(ex)
Exception: ConnectAuthError(172.25.92.59)
```

### New Behavior
```
ddivins@ddivins-mbp jsnap % jsnapy --snap pre -f config_check.yml -v
jsnapy.cfg file location used : /Users/ddivins/Library/CloudStorage/OneDrive-JuniperNetworks,Inc/Documents/PycharmProjects/jsnap/venv/etc/jsnapy
Configuration file location used : /etc/jsnapy
Connecting to device 172.25.92.59 ................

Enter User name: lab

Enter Password for username <lab> : 
Connecting to device 172.25.92.59 ................
Tests Included : test_ntp_source 
Taking snapshot of RPC: get-config
Tests Included: test_ntp_status 
Taking snapshot of COMMAND: show ntp status 
Tests Included: test_ntp_association 
Taking snapshot of COMMAND: show ntp association 
```
### Tests written?

Above was my test as well as using -l and -u from command and that still works