### PR TITLE
fix for jsnapy username and password prompt

### DIFF
--- a/lib/jnpr/jsnapy/jsnapy.py
+++ b/lib/jnpr/jsnapy/jsnapy.py
@@ -666,7 +666,7 @@ class SnapAdmin:
             try:
                 dev.open()
             except ConnectAuthError as ex:
-                if password is None and action is None:
+                if password is None:
                     password = getpass.getpass(
                         "\nEnter Password for username <%s> : " % username
                     )


### PR DESCRIPTION
Jsnapy prompt failing for password after giving username. Fix is to remove 'AND' clause with password and action field as None action is already handled and will cause 'AND' clause to fail otherwise.  
