### PR TITLE
Fix no_diff with missing pre and post snapfile

### DIFF
--- a/lib/jnpr/jsnapy/operator.py
+++ b/lib/jnpr/jsnapy/operator.py
@@ -2739,6 +2739,18 @@ class Operator:
                 + "ERROR!! 'no-diff' operator requires node value to test !!",
                 extra=self.log_detail,
             )
+        elif xml1 is None or xml2 is None:
+            self._error_nodes_logger("Xpath for snapshot", x_path)
+            res = False
+            count_fail = count_fail + 1
+            node_value_failed = {
+                "id": iddict,
+                "pre": predict,
+                "post": postdict,
+                "actual_node_value": None,
+                "xpath_error": True,
+            }
+            tresult["failed"].append(deepcopy(node_value_failed))
         else:
             if (not pre_nodes) or (not post_nodes):
                 # if ignore_null is True, just skip
@@ -2873,7 +2885,8 @@ class Operator:
                     else:
                         # mapping id name to its value
                         for length in range(len(k)):
-                            id_val[id_list[length]] = k[length][0].strip()
+                            if (len(k[0]) > 0):
+                                id_val[id_list[length]] = k[length][0].strip()
                         if k in data1:
                             predict, postdict = self._get_nodevalue(
                                 predict,

--- a/lib/jnpr/jsnapy/operator.py
+++ b/lib/jnpr/jsnapy/operator.py
@@ -2885,7 +2885,7 @@ class Operator:
                     else:
                         # mapping id name to its value
                         for length in range(len(k)):
-                            if (len(k[0]) > 0):
+                            if len(k[0]) > 0:
                                 id_val[id_list[length]] = k[length][0].strip()
                         if k in data1:
                             predict, postdict = self._get_nodevalue(

--- a/lib/jnpr/jsnapy/operator.py
+++ b/lib/jnpr/jsnapy/operator.py
@@ -559,8 +559,8 @@ class Operator:
                         count_pass = count_pass + 1
                         node_value_passed = {
                             "id": id_val,
-                            "PRE": predict,
-                            "POST": postdict,
+                            "pre": predict,
+                            "post": postdict,
                             "message": message,
                         }
                         tresult["passed"].append(deepcopy(node_value_passed))


### PR DESCRIPTION
### What does this PR do?
Fix  for issue #413
Handles the combination for check with no_diff operator, when pre or post snapshot file/ data is missing.

### What issues does this PR fix or reference?
issue #413 
### Previous Behavior
Remove this section if not relevant
with missing presnapshot file, test case Passed

### New Behavior
Remove this section if not relevant
with missing pre snapshot file, test case fails with error

### Tests written?
No
Yes/No
