### PR TITLE
jsnap2py indentation fix

### DIFF
--- a/lib/jnpr/jsnapy/operator.py
+++ b/lib/jnpr/jsnapy/operator.py
@@ -420,6 +420,7 @@ class Operator:
                 % (element, x_path, count_pass, count_fail)
             )
             self._print_result(msg, res)
+            tresult['err'] = err_mssg
         elif res is True:
             msg = 'All "%s" exists at xpath "%s" [ %d value matched ]' % (
                 element,
@@ -427,6 +428,7 @@ class Operator:
                 count_pass,
             )
             self._print_result(msg, res)
+            tresult['info'] = info_mssg
 
         # tresult['info'] = info_mssg
         # tresult['err'] = err_mssg

--- a/tools/jsnap2py
+++ b/tools/jsnap2py
@@ -27,7 +27,7 @@ def msg_change(x):
             data = (data[0],data[1][1:])
         if data[0] in ['id', 'ID']:
             data = (data[0], int(data[1])-1)
-	    msg = "{{%s_%s}}" % (data)
+            msg = "{{%s_%s}}" % (data)
         elif data[0] in ['PRE', 'POST']:
             msg = '{{%s["%s"]}}' % (data)
         else:
@@ -120,7 +120,7 @@ else:
                                     '\$id\.\d|\$pre\s?/?\.?/\s?[\w-]+/?[\w-]*|\$post\s?/?\.?/\s?[\w-]+/?[\w-]*|,\s?\.{0,2}/?\.{0,2}/?[\w-]+/?[\w-]*/?[\w-]*',
                                     data.group(2),
                                     re.I)
-                                inputs = map(msg_change, inputs)
+                                inputs = list(map(msg_change, inputs))
                             to_format = re.search('"(.*?)"', obj.group(2))
                             if len(inputs) > 0:
                                 if to_format:


### PR DESCRIPTION
### What does this PR do?
fix for following exceptions.

at line number 30, indentation was wrong 
at line number 123, method len is not member of object map.

### What issues does this PR fix or reference?
Fix for issue #327 
### Previous Behavior
$ jsnap2py --version
  File "/usr/bin/jsnap2py", line 30
    msg = "{{%s_%s}}" % (data)
                             ^
TabError: inconsistent use of tabs and spaces in indentation

### New Behavior
jsnap2py -i test_is_equal.conf -o test_ospf.yml


### Tests written?

Yes/No
Yes
```
cat test_is_equal.conf 
do {
      check_ospf;
}

check_ospf {
      command  show configuration protocols ospf ;
      item route-engine {
           is-equal mastership-state, "master" {
             info "Checking if RE0 is the Master RE ...";
             err " ERROR: RE0 is not the Master RE. Its current state is %s", $POST/mastership-state;
          }
      }
}


jsnap2py -i test_is_equal.conf -o test_ospf.yml

cat test_ospf.yml 
check_ospf:
- command: 'show configuration protocols ospf '
- item:
    tests:
    - err: ' ERROR: RE0 is not the Master RE. Its current state is {{post["mastership-state"]}}'
      info: Checking if RE0 is the Master RE ...
      is-equal: mastership-state, master
    xpath: route-engine
tests_include:
- check_ospf
```
